### PR TITLE
Convert FFI API to raw pointers

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -18,7 +18,7 @@ pub struct SceneInfo<'a> {
     pub images: &'a [&'a str],
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 #[repr(C)]
 pub struct DirectionalLightInfo {
     pub direction: Vec4,
@@ -26,7 +26,11 @@ pub struct DirectionalLightInfo {
     pub intensity: f32,
 }
 
-pub struct DirectionalLight {}
+#[derive(Default)]
+pub struct DirectionalLight {
+    pub transform: Mat4,
+    pub info: DirectionalLightInfo,
+}
 pub struct CameraInfo<'a> {
     pub pass: &'a str,
     pub transform: Mat4,
@@ -50,6 +54,7 @@ pub struct RenderEngine {
     database: Database,
     event_cb: Option<EventCallbackInfo>,
     mesh_objects: Pool<MeshObject>,
+    directional_lights: Pool<DirectionalLight>,
 }
 
 #[allow(dead_code)]
@@ -69,49 +74,65 @@ impl RenderEngine {
 
         // The GPU context that holds all the data.
         let mut ctx = Box::new(gpu::Context::new(&ContextInfo { device }).unwrap());
-//        let event_pump = ctx.get_sdl_ctx().event_pump().unwrap();
-//        let mut scene = Box::new(miso::Scene::new(
-//            &mut ctx,
-//            &miso::SceneInfo {
-//                cfg: cfg.scene_cfg_path,
-//            },
-//        ));
+        //        let event_pump = ctx.get_sdl_ctx().event_pump().unwrap();
+        //        let mut scene = Box::new(miso::Scene::new(
+        //            &mut ctx,
+        //            &miso::SceneInfo {
+        //                cfg: cfg.scene_cfg_path,
+        //            },
+        //        ));
 
-        let database =
-            Database::new(cfg.database_path.as_ref().unwrap(), &mut ctx).unwrap();
+        let database = Database::new(cfg.database_path.as_ref().unwrap(), &mut ctx).unwrap();
 
-//        let global_camera = scene.register_camera(&CameraInfo {
-//            pass: "ALL",
-//            transform: Default::default(),
-//            projection: Default::default(),
-//        });
+        //        let global_camera = scene.register_camera(&CameraInfo {
+        //            pass: "ALL",
+        //            transform: Default::default(),
+        //            projection: Default::default(),
+        //        });
 
         let s = Self {
             ctx,
-//            scene,
+            //            scene,
             database,
             event_cb: None,
             mesh_objects: Default::default(),
-//            global_camera,
+            directional_lights: Default::default(),
+            //            global_camera,
         };
 
         s
     }
 
-    pub fn register_directional_light(&mut self, info: &DirectionalLightInfo) -> Handle<DirectionalLight> {
-        todo!()
-//        self.scene.register_directional_light(info)
+    pub fn register_directional_light(
+        &mut self,
+        info: &DirectionalLightInfo,
+    ) -> Handle<DirectionalLight> {
+        let light = DirectionalLight {
+            transform: Mat4::IDENTITY,
+            info: *info,
+        };
+        self.directional_lights.insert(light).unwrap()
+    }
+
+    pub fn set_directional_light_transform(
+        &mut self,
+        handle: Handle<DirectionalLight>,
+        transform: &Mat4,
+    ) {
+        if let Some(light) = self.directional_lights.get_mut_ref(handle) {
+            light.transform = *transform;
+        }
     }
 
     pub fn register_mesh_object(&mut self, info: &FFIMeshObjectInfo) -> Handle<MeshObject> {
         todo!()
-//        let info: MeshObjectInfo = info.into();
-//        info!(
-//            "Registering Mesh Object {} with material {}",
-//            info.mesh, info.material
-//        );
- //       let object = info.make_object(&mut self.database, &mut self.scene);
-//        self.mesh_objects.insert(object).unwrap()
+        //        let info: MeshObjectInfo = info.into();
+        //        info!(
+        //            "Registering Mesh Object {} with material {}",
+        //            info.mesh, info.material
+        //        );
+        //       let object = info.make_object(&mut self.database, &mut self.scene);
+        //        self.mesh_objects.insert(object).unwrap()
     }
 
     pub fn set_mesh_object_transform(
@@ -119,46 +140,46 @@ impl RenderEngine {
         handle: Handle<MeshObject>,
         transform: &glam::Mat4,
     ) {
-//        if let Some(m) = self.mesh_objects.get_ref(handle) {
-//            for t in &m.targets {
-//                self.scene.update_object_transform(*t, transform);
-//            }
-//        }
+        //        if let Some(m) = self.mesh_objects.get_ref(handle) {
+        //            for t in &m.targets {
+        //                self.scene.update_object_transform(*t, transform);
+        //            }
+        //        }
     }
 
     pub fn update(&mut self, _delta_time: f32) {
-//        for event in self.event_pump.poll_iter() {
-//            if let Some(cb) = self.event_cb.as_mut() {
-//                let mut e: event::Event = event.into();
-//                let c = cb.event_cb;
-//                c(&mut e, cb.user_data);
-//            }
-//        }
+        //        for event in self.event_pump.poll_iter() {
+        //            if let Some(cb) = self.event_cb.as_mut() {
+        //                let mut e: event::Event = event.into();
+        //                let c = cb.event_cb;
+        //                c(&mut e, cb.user_data);
+        //            }
+        //        }
 
-//        self.scene.update();
+        //        self.scene.update();
     }
 
     pub fn set_projection(&mut self, proj: &Mat4) {
-//        self.scene
-//            .update_camera_projection(self.global_camera, proj);
+        //        self.scene
+        //            .update_camera_projection(self.global_camera, proj);
     }
-    
+
     pub fn set_capture_mouse(&mut self, capture: bool) {
-//        self.ctx.get_sdl_ctx().mouse().set_relative_mouse_mode(capture);
+        //        self.ctx.get_sdl_ctx().mouse().set_relative_mouse_mode(capture);
     }
     pub fn set_camera(&mut self, camera: &Mat4) {
- //       self.scene
- //           .update_camera_transform(self.global_camera, camera);
+        //       self.scene
+        //           .update_camera_transform(self.global_camera, camera);
     }
     pub fn set_event_cb(
         &mut self,
         event_cb: extern "C" fn(*mut event::Event, *mut c_void),
         user_data: *mut c_void,
     ) {
- //       self.event_cb = Some(EventCallbackInfo {
- //           event_cb,
- //           user_data,
- //       });
+        //       self.event_cb = Some(EventCallbackInfo {
+        //           event_cb,
+        //           user_data,
+        //       });
     }
 
     pub fn set_scene(&mut self, _info: &SceneInfo) {


### PR DESCRIPTION
## Summary
- expose `meshi_make_engine` and add `meshi_destroy_engine`
- use raw pointers for all public FFI functions
- update engine update loop to advance physics
- add a pool of directional lights and allow modifying their transform
- document exported structs and functions

## Testing
- `cargo fmt --all`
- `cargo test --quiet` *(fails: repository uses git dependencies and needs network)*

------
https://chatgpt.com/codex/tasks/task_e_688d2c851700832aa7588732a2afc383