### PR TITLE
Implement scene loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,8 @@ harness = false
 name = "mesh_physics"
 path = "tests/mesh_physics.rs"
 harness = false
+
+[[test]]
+name = "scene"
+path = "tests/scene.rs"
+harness = false

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -210,7 +210,16 @@ impl RenderEngine {
         self.event_cb = Some(EventCallbackInfo { event_cb, user_data });
     }
 
-    pub fn set_scene(&mut self, _info: &SceneInfo) {
-        todo!()
+    /// Load the resources referenced by `SceneInfo` into the renderer's
+    /// database. Models and images that fail to load will return an error so
+    /// callers can react accordingly.
+    pub fn set_scene(&mut self, info: &SceneInfo) -> Result<(), database::Error> {
+        for m in info.models {
+            self.database.load_model(m)?;
+        }
+        for i in info.images {
+            self.database.load_image(i)?;
+        }
+        Ok(())
     }
 }

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -1,0 +1,46 @@
+use meshi::render::{RenderEngine, RenderEngineInfo, SceneInfo};
+use std::fs;
+use image::{RgbaImage, Rgba};
+
+fn main() {
+    // Skip test when no display is available, similar to existing tests.
+    if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
+        return;
+    }
+
+    // Create a temporary directory for the database resources.
+    let mut dir = std::env::temp_dir();
+    dir.push("meshi_scene_test");
+    // Ensure a unique directory per run.
+    dir.push(format!("{}", std::time::SystemTime::now().elapsed().unwrap().as_nanos()));
+    fs::create_dir_all(&dir).unwrap();
+    let db_dir = dir.join("database");
+    fs::create_dir_all(&db_dir).unwrap();
+
+    // Minimal db.json so Database::new succeeds.
+    fs::write(db_dir.join("db.json"), "{}").unwrap();
+
+    // Dummy model file.
+    fs::write(db_dir.join("model.gltf"), b"test").unwrap();
+
+    // Dummy image file using the image crate.
+    let img_path = db_dir.join("albedo.png");
+    let mut img = RgbaImage::new(1,1);
+    img.put_pixel(0,0,Rgba([255,0,0,255]));
+    img.save(&img_path).unwrap();
+
+    // Initialise renderer pointing at our temp directory.
+    let mut render = RenderEngine::new(&RenderEngineInfo {
+        application_path: dir.to_str().unwrap().into(),
+        scene_info: None,
+    });
+
+    // Configure the scene.
+    let scene_info = SceneInfo {
+        models: &["model.gltf"],
+        images: &["albedo.png"],
+    };
+
+    // Ensure loading succeeds.
+    render.set_scene(&scene_info).expect("scene loading failed");
+}


### PR DESCRIPTION
## Summary
- Load models and images listed in `SceneInfo` into the renderer database
- Add helpers in database for loading model and image files
- Provide test demonstrating scene configuration

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688d9597f09c832a87e82aa60f1b5aba