### PR TITLE
Add physics update test for gravity and damping

### DIFF
--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -186,4 +186,9 @@ impl PhysicsSimulation {
         assert!(h.valid());
         self.rigid_bodies.get_ref(h).unwrap().into()
     }
+
+    pub fn get_rigid_body_velocity(&self, h: Handle<RigidBody>) -> Vec3 {
+        assert!(h.valid());
+        self.rigid_bodies.get_ref(h).unwrap().velocity
+    }
 }

--- a/tests/physics_update.rs
+++ b/tests/physics_update.rs
@@ -1,0 +1,24 @@
+use meshi::physics::{MaterialInfo, PhysicsSimulation, RigidBodyInfo, SimulationInfo};
+
+#[test]
+fn physics_update_applies_gravity_and_damping() {
+    let mut sim = PhysicsSimulation::new(&SimulationInfo::default());
+    let rb = sim.create_rigid_body(&RigidBodyInfo {
+        has_gravity: 1,
+        ..Default::default()
+    });
+
+    let dt = 1.0f32;
+    sim.update(dt);
+
+    let status = sim.get_rigid_body_status(rb);
+    let velocity = sim.get_rigid_body_velocity(rb);
+
+    let g = -9.8f32;
+    let friction = MaterialInfo::default().dynamic_friction_m;
+    let expected_position_y = g * dt * dt;
+    let expected_velocity_y = (g - friction) * dt;
+
+    assert!((status.position.y - expected_position_y).abs() < 1e-5);
+    assert!((velocity.y - expected_velocity_y).abs() < 1e-5);
+}


### PR DESCRIPTION
## Summary
- expose rigid body velocity for inspection
- test physics update applies gravity and dynamic friction

## Testing
- `cargo test --test physics_update`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688d95a4f558832aba031dfa50123190