### PR TITLE
docs: add build and usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# meshi
+
+This crate builds a dynamic library that can be consumed via FFI and also provides examples and tests.
+
+## Dependencies
+
+To build and run the library, ensure the following Rust crates and their native dependencies are available:
+
+- [dashi](https://github.com/JordanHendl/dashi)
+- [koji](https://github.com/JordanHendl/koji)
+
+## Build
+
+Compile the dynamic library in release mode:
+
+```bash
+cargo build --release
+```
+
+The library artifact will be placed in `target/release`.
+
+## Test
+
+Run the test suite to verify functionality:
+
+```bash
+cargo test
+```
+
+## Examples
+
+Sample code demonstrating the FFI interface lives in the `examples/` directory. Run an example with:
+
+```bash
+cargo run --example ffi_init
+```
+
+Replace `ffi_init` with `ffi_physics` to explore the physics example.
+


### PR DESCRIPTION
## Summary
- document project dependencies
- add build instructions for the dynamic library
- explain how to run tests and examples
- correct dependency list to only include required crates

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688da7c58efc832a8397ec42f6ad79fd