### PR TITLE
Implement mesh object creation via database

### DIFF
--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -1,6 +1,6 @@
 pub mod error;
 use dashi::{utils::Handle, Buffer};
-use tracing::{debug, info};
+use tracing::info;
 
 pub use error::*;
 pub mod json;
@@ -153,11 +153,14 @@ impl Database {
             geometry_primitives::make_sphere(&Default::default(), ctx),
         );
 
+        let mut textures = HashMap::new();
+        textures.insert("DEFAULT".to_string(), Some(Handle::default()));
+
         let db = Database {
             base_path: base_path.to_string(),
             ctx,
             geometry,
-            textures: HashMap::new(),
+            textures,
         };
 
  //       let ptr: *mut Database = &mut db;
@@ -269,6 +272,18 @@ impl Database {
                 *entry = Some(handle);
                 Ok(handle)
             }
+            None => Err(Error::LookupError(LookupError {
+                entry: name.to_string(),
+            })),
+        }
+    }
+    pub fn fetch_material(&mut self, name: &str) -> Result<Handle<koji::Texture>, Error> {
+        self.fetch_texture(name)
+    }
+
+    pub fn fetch_mesh(&self, name: &str) -> Result<MeshResource, Error> {
+        match self.geometry.get(name) {
+            Some(mesh) => Ok(mesh.clone()),
             None => Err(Error::LookupError(LookupError {
                 entry: name.to_string(),
             })),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -127,7 +127,9 @@ impl RenderEngine {
 
     pub fn register_mesh_object(&mut self, info: &FFIMeshObjectInfo) -> Handle<MeshObject> {
         let info: MeshObjectInfo = info.into();
-        let object = info.make_object(&mut self.database);
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -137,7 +139,9 @@ impl RenderEngine {
             material: "MESHI_CUBE",
             transform: Mat4::IDENTITY,
         };
-        let object = info.make_object(&mut self.database);
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -147,7 +151,9 @@ impl RenderEngine {
             material: "MESHI_SPHERE",
             transform: Mat4::IDENTITY,
         };
-        let object = info.make_object(&mut self.database);
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -157,7 +163,9 @@ impl RenderEngine {
             material: "MESHI_TRIANGLE",
             transform: Mat4::IDENTITY,
         };
-        let object = info.make_object(&mut self.database);
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
         self.mesh_objects.insert(object).unwrap()
     }
 


### PR DESCRIPTION
## Summary
- populate MeshObject by fetching mesh/material handles from Database
- expose helpers in Database to lookup meshes and materials, seed default texture
- handle Result when creating mesh objects in renderer

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e43e3d5f4832ab18c4ac3a32c648d