### PR TITLE
Add headless mode flag and convenience wrapper

### DIFF
--- a/examples/ffi_init.rs
+++ b/examples/ffi_init.rs
@@ -1,14 +1,17 @@
-use meshi::*;
 use glam::Mat4;
+use meshi::*;
 use std::ffi::CString;
 
 fn main() {
     let app = CString::new("Example").unwrap();
     let loc = CString::new(".").unwrap();
-    let info = MeshiEngineInfo { application_name: app.as_ptr(), application_location: loc.as_ptr() };
-    let engine = unsafe { meshi_make_engine(&info) };
+    let engine = unsafe { meshi_make_engine_headless(app.as_ptr(), loc.as_ptr()) };
     let render = unsafe { meshi_get_graphics_system(engine) };
     let cube = unsafe { meshi_gfx_create_cube(render) };
-    unsafe { meshi_gfx_set_renderable_transform(render, cube, &Mat4::IDENTITY); }
-    unsafe { meshi_destroy_engine(engine); }
+    unsafe {
+        meshi_gfx_set_renderable_transform(render, cube, &Mat4::IDENTITY);
+    }
+    unsafe {
+        meshi_destroy_engine(engine);
+    }
 }

--- a/examples/ffi_physics.rs
+++ b/examples/ffi_physics.rs
@@ -1,20 +1,38 @@
-use meshi::*;
+use glam::{Quat, Vec3};
 use meshi::physics::{ActorStatus, RigidBodyInfo};
-use glam::{Vec3, Quat};
+use meshi::*;
 use std::ffi::CString;
 
 fn main() {
     let app = CString::new("Example").unwrap();
     let loc = CString::new(".").unwrap();
-    let info = MeshiEngineInfo { application_name: app.as_ptr(), application_location: loc.as_ptr() };
+    let info = MeshiEngineInfo {
+        application_name: app.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 1,
+    };
     let engine = unsafe { meshi_make_engine(&info) };
     let physics = unsafe { meshi_get_physics_system(engine) };
     let rb = unsafe { meshi_physx_create_rigid_body(physics, &RigidBodyInfo::default()) };
-    let status = ActorStatus { position: Vec3::new(1.0, 0.0, 0.0), rotation: Quat::IDENTITY };
-    unsafe { meshi_physx_set_rigid_body_transform(physics, &rb, &status); }
+    let status = ActorStatus {
+        position: Vec3::new(1.0, 0.0, 0.0),
+        rotation: Quat::IDENTITY,
+    };
+    unsafe {
+        meshi_physx_set_rigid_body_transform(physics, &rb, &status);
+    }
     let mut out = ActorStatus::default();
-    unsafe { meshi_physx_get_rigid_body_status(physics, &rb, &mut out); }
-    println!("Rigid body position: {} {} {}", out.position.x, out.position.y, out.position.z);
-    unsafe { meshi_physx_release_rigid_body(physics, &rb); }
-    unsafe { meshi_destroy_engine(engine); }
+    unsafe {
+        meshi_physx_get_rigid_body_status(physics, &rb, &mut out);
+    }
+    println!(
+        "Rigid body position: {} {} {}",
+        out.position.x, out.position.y, out.position.z
+    );
+    unsafe {
+        meshi_physx_release_rigid_body(physics, &rb);
+    }
+    unsafe {
+        meshi_destroy_engine(engine);
+    }
 }

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,5 +1,5 @@
-use std::ffi::CString;
 use meshi::*;
+use std::ffi::CString;
 
 fn main() {
     if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
@@ -8,8 +8,14 @@ fn main() {
     }
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
-    let info = MeshiEngineInfo { application_name: name.as_ptr(), application_location: loc.as_ptr() };
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 0,
+    };
     let engine = unsafe { meshi_make_engine(&info) };
     assert!(!engine.is_null());
-    unsafe { meshi_destroy_engine(engine); }
+    unsafe {
+        meshi_destroy_engine(engine);
+    }
 }

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -1,7 +1,10 @@
-use std::ffi::{c_void, CString};
-use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
-use meshi::*;
 use meshi::render::event::Event;
+use meshi::*;
+use std::ffi::{c_void, CString};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 extern "C" fn cb(_ev: *mut Event, data: *mut c_void) {
     let counter: &AtomicUsize = unsafe { &*(data as *const AtomicUsize) };
@@ -14,7 +17,11 @@ fn main() {
     }
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
-    let info = MeshiEngineInfo { application_name: name.as_ptr(), application_location: loc.as_ptr() };
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 0,
+    };
     let engine = unsafe { meshi_make_engine(&info) };
     let counter = Arc::new(AtomicUsize::new(0));
     unsafe {

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -1,7 +1,7 @@
-use std::ffi::CString;
-use meshi::*;
+use glam::{Mat4, Quat, Vec3};
 use meshi::physics::{ActorStatus, RigidBodyInfo};
-use glam::{Mat4, Vec3, Quat};
+use meshi::*;
+use std::ffi::CString;
 
 fn main() {
     if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
@@ -9,25 +9,42 @@ fn main() {
     }
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
-    let info = MeshiEngineInfo { application_name: name.as_ptr(), application_location: loc.as_ptr() };
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 0,
+    };
     let engine = unsafe { meshi_make_engine(&info) };
 
     // Graphics mesh object
     let render = unsafe { meshi_get_graphics_system(engine) };
     let cube = unsafe { meshi_gfx_create_cube(render) };
     let transform = Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0));
-    unsafe { meshi_gfx_set_renderable_transform(render, cube, &transform); }
+    unsafe {
+        meshi_gfx_set_renderable_transform(render, cube, &transform);
+    }
 
     // Physics rigid body
     let physics = unsafe { meshi_get_physics_system(engine) };
     let rb = unsafe { meshi_physx_create_rigid_body(physics, &RigidBodyInfo::default()) };
-    let new_status = ActorStatus { position: Vec3::new(4.0,5.0,6.0), rotation: Quat::IDENTITY };
-    unsafe { meshi_physx_set_rigid_body_transform(physics, &rb, &new_status); }
+    let new_status = ActorStatus {
+        position: Vec3::new(4.0, 5.0, 6.0),
+        rotation: Quat::IDENTITY,
+    };
+    unsafe {
+        meshi_physx_set_rigid_body_transform(physics, &rb, &new_status);
+    }
     let mut out = ActorStatus::default();
-    unsafe { meshi_physx_get_rigid_body_status(physics, &rb, &mut out); }
+    unsafe {
+        meshi_physx_get_rigid_body_status(physics, &rb, &mut out);
+    }
     assert_eq!(out.position, new_status.position);
     assert_eq!(out.rotation, new_status.rotation);
 
-    unsafe { meshi_physx_release_rigid_body(physics, &rb); }
-    unsafe { meshi_destroy_engine(engine); }
+    unsafe {
+        meshi_physx_release_rigid_body(physics, &rb);
+    }
+    unsafe {
+        meshi_destroy_engine(engine);
+    }
 }


### PR DESCRIPTION
## Summary
- add `headless` flag to `MeshiEngineInfo`
- forward headless flag to renderer
- expose `meshi_make_engine_headless` wrapper and update examples/tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e4f6b04cc832a9512bd74a5ff4d40