### PR TITLE
feat: implement database error traits

### DIFF
--- a/src/render/database/error.rs
+++ b/src/render/database/error.rs
@@ -1,4 +1,8 @@
 use std::fmt;
+
+/// A convenient result type wrapping [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug)]
 pub struct SlotError {}
 
@@ -38,11 +42,38 @@ impl fmt::Display for LoadingError {
         )
     }
 }
+
+impl std::error::Error for SlotError {}
+
+impl std::error::Error for LookupError {}
+
+impl std::error::Error for LoadingError {}
+
 #[derive(Debug)]
 pub enum Error {
     LookupError(LookupError),
     LoadingError(LoadingError),
     SlotError(),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::LookupError(err) => err.fmt(f),
+            Error::LoadingError(err) => err.fmt(f),
+            Error::SlotError() => SlotError {}.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::LookupError(err) => Some(err),
+            Error::LoadingError(err) => Some(err),
+            Error::SlotError() => None,
+        }
+    }
 }
 
 impl From<String> for Error {

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -52,7 +52,7 @@ impl Database {
     pub fn new(
         base_path: &str,
         ctx: &mut dashi::Context,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self> {
         info!("Loading Database {}", format!("{}/db.json", base_path));
         let _json_data = fs::read_to_string(format!("{}/db.json", base_path))?;
 //        let info: json::Database = serde_json::from_str(&json_data)?;
@@ -201,7 +201,7 @@ impl Database {
     /// model is considered loaded once the file exists and is readable. The
     /// currently stubbed implementation simply registers the model name so
     /// that it can be retrieved later by tests or callers.
-    pub fn load_model(&mut self, name: &str) -> Result<(), Error> {
+    pub fn load_model(&mut self, name: &str) -> Result<()> {
         let path = format!("{}/{}", self.base_path, name);
         // Ensure the file exists on disk.
         fs::read(&path)?;
@@ -220,7 +220,7 @@ impl Database {
     /// The image path is resolved relative to the database base path. The
     /// image is decoded using the `image` crate to ensure it is valid. Loaded
     /// image names are tracked so subsequent calls are inexpensive.
-    pub fn load_image(&mut self, name: &str) -> Result<(), Error> {
+    pub fn load_image(&mut self, name: &str) -> Result<()> {
         if self.textures.contains_key(name) {
             return Ok(());
         }
@@ -256,7 +256,7 @@ impl Database {
  //       );
  //   }
 
-    pub fn fetch_texture(&mut self, name: &str) -> Result<Handle<koji::Texture>, Error> {
+    pub fn fetch_texture(&mut self, name: &str) -> Result<Handle<koji::Texture>> {
         match self.textures.get_mut(name) {
             Some(entry) => {
                 if let Some(handle) = entry {
@@ -277,11 +277,11 @@ impl Database {
             })),
         }
     }
-    pub fn fetch_material(&mut self, name: &str) -> Result<Handle<koji::Texture>, Error> {
+    pub fn fetch_material(&mut self, name: &str) -> Result<Handle<koji::Texture>> {
         self.fetch_texture(name)
     }
 
-    pub fn fetch_mesh(&self, name: &str) -> Result<MeshResource, Error> {
+    pub fn fetch_mesh(&self, name: &str) -> Result<MeshResource> {
         match self.geometry.get(name) {
             Some(mesh) => Ok(mesh.clone()),
             None => Err(Error::LookupError(LookupError {


### PR DESCRIPTION
## Summary
- implement `std::error::Error` for `SlotError`, `LookupError`, `LoadingError`, and the `Error` enum
- add `Result<T>` type alias and use it in database APIs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e4f7ebe14832aa33b9ca927fa4711