### PR TITLE
Refactor RenderEngine initialization to propagate errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,8 @@ impl MeshiEngine {
                 application_path: appdir.to_string(),
                 scene_info: None,
                 headless: info.headless != 0,
-            }),
+            })
+            .expect("failed to initialize render engine"),
             physics: Box::new(PhysicsSimulation::new(&Default::default())),
             frame_timer: Timer::new(),
             name: appname.to_string(),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,10 +1,10 @@
-use std::ffi::c_void;
+use std::{ffi::c_void, fmt};
 
 use dashi::{
     utils::{Handle, Pool},
     *,
 };
-use database::Database;
+use database::{Database, Error as DatabaseError};
 use glam::{Mat4, Vec4};
 use tracing::info;
 
@@ -12,6 +12,40 @@ use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo};
 pub mod config;
 pub mod database;
 pub mod event;
+
+#[derive(Debug)]
+pub enum RenderError {
+    DeviceSelection,
+    ContextCreation,
+    DisplayCreation,
+    Database(DatabaseError),
+}
+
+impl fmt::Display for RenderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenderError::DeviceSelection => write!(f, "failed to select device"),
+            RenderError::ContextCreation => write!(f, "failed to create GPU context"),
+            RenderError::DisplayCreation => write!(f, "failed to create display"),
+            RenderError::Database(err) => write!(f, "database error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for RenderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RenderError::Database(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<DatabaseError> for RenderError {
+    fn from(value: DatabaseError) -> Self {
+        RenderError::Database(value)
+    }
+}
 
 pub struct SceneInfo<'a> {
     pub models: &'a [&'a str],
@@ -62,9 +96,9 @@ pub struct RenderEngine {
 
 #[allow(dead_code)]
 impl RenderEngine {
-    pub fn new(info: &RenderEngineInfo) -> Self {
-        let device = DeviceSelector::new()
-            .unwrap()
+    pub fn new(info: &RenderEngineInfo) -> Result<Self, RenderError> {
+        let device_selector = DeviceSelector::new().map_err(|_| RenderError::DeviceSelection)?;
+        let device = device_selector
             .select(DeviceFilter::default().add_required_type(DeviceType::Dedicated))
             .unwrap_or_default();
 
@@ -77,15 +111,24 @@ impl RenderEngine {
 
         // The GPU context that holds all the data.
         let mut ctx = if info.headless {
-            Box::new(gpu::Context::headless(&ContextInfo { device }).unwrap())
+            Box::new(
+                gpu::Context::headless(&ContextInfo { device })
+                    .map_err(|_| RenderError::ContextCreation)?,
+            )
         } else {
-            Box::new(gpu::Context::new(&ContextInfo { device }).unwrap())
+            Box::new(
+                gpu::Context::new(&ContextInfo { device })
+                    .map_err(|_| RenderError::ContextCreation)?,
+            )
         };
 
         let display = if info.headless {
             None
         } else {
-            Some(ctx.make_display(&Default::default()).unwrap())
+            Some(
+                ctx.make_display(&Default::default())
+                    .map_err(|_| RenderError::DisplayCreation)?,
+            )
         };
 
         let event_loop = if info.headless {
@@ -101,7 +144,7 @@ impl RenderEngine {
         //            },
         //        ));
 
-        let database = Database::new(cfg.database_path.as_ref().unwrap(), &mut ctx).unwrap();
+        let database = Database::new(cfg.database_path.as_ref().unwrap(), &mut ctx)?;
 
         //        let global_camera = scene.register_camera(&CameraInfo {
         //            pass: "ALL",
@@ -119,7 +162,7 @@ impl RenderEngine {
             directional_lights: Default::default(),
         };
 
-        s
+        Ok(s)
     }
 
     pub fn register_directional_light(
@@ -253,7 +296,10 @@ impl RenderEngine {
         event_cb: extern "C" fn(*mut event::Event, *mut c_void),
         user_data: *mut c_void,
     ) {
-        self.event_cb = Some(EventCallbackInfo { event_cb, user_data });
+        self.event_cb = Some(EventCallbackInfo {
+            event_cb,
+            user_data,
+        });
     }
 
     /// Load the resources referenced by `SceneInfo` into the renderer's

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -1,6 +1,6 @@
+use image::{Rgba, RgbaImage};
 use meshi::render::{RenderEngine, RenderEngineInfo, SceneInfo};
 use std::fs;
-use image::{RgbaImage, Rgba};
 
 fn main() {
     // Skip test when no display is available, similar to existing tests.
@@ -12,7 +12,10 @@ fn main() {
     let mut dir = std::env::temp_dir();
     dir.push("meshi_scene_test");
     // Ensure a unique directory per run.
-    dir.push(format!("{}", std::time::SystemTime::now().elapsed().unwrap().as_nanos()));
+    dir.push(format!(
+        "{}",
+        std::time::SystemTime::now().elapsed().unwrap().as_nanos()
+    ));
     fs::create_dir_all(&dir).unwrap();
     let db_dir = dir.join("database");
     fs::create_dir_all(&db_dir).unwrap();
@@ -25,8 +28,8 @@ fn main() {
 
     // Dummy image file using the image crate.
     let img_path = db_dir.join("albedo.png");
-    let mut img = RgbaImage::new(1,1);
-    img.put_pixel(0,0,Rgba([255,0,0,255]));
+    let mut img = RgbaImage::new(1, 1);
+    img.put_pixel(0, 0, Rgba([255, 0, 0, 255]));
     img.save(&img_path).unwrap();
 
     // Initialise renderer pointing at our temp directory.
@@ -34,7 +37,8 @@ fn main() {
         application_path: dir.to_str().unwrap().into(),
         scene_info: None,
         headless: false,
-    });
+    })
+    .expect("failed to initialize renderer");
 
     // Configure the scene.
     let scene_info = SceneInfo {


### PR DESCRIPTION
## Summary
- add `RenderError` enum for device, context, display, and database failures
- make `RenderEngine::new` return `Result` and replace `unwrap` calls
- update engine creation sites to handle the fallible constructor

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e7aed0e80832a90dab1185fc8a6fe