### PR TITLE
Handle additional input events

### DIFF
--- a/tests/event.rs
+++ b/tests/event.rs
@@ -1,9 +1,14 @@
-use meshi::render::event::Event;
+use glam::vec2;
+use meshi::render::event::{from_winit_event, Event, EventSource, EventType};
 use meshi::*;
 use std::ffi::{c_void, CString};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
+};
+use winit::event::{
+    DeviceEvent, ElementState, Event as WEvent, MouseScrollDelta, TouchPhase, WindowEvent,
+    ModifiersState,
 };
 
 extern "C" fn cb(_ev: *mut Event, data: *mut c_void) {
@@ -12,6 +17,64 @@ extern "C" fn cb(_ev: *mut Event, data: *mut c_void) {
 }
 
 fn main() {
+    // Test conversion from winit events
+    let window_id: winit::window::WindowId = unsafe { std::mem::zeroed() };
+
+    let wheel_event = WEvent::WindowEvent {
+        window_id,
+        event: WindowEvent::MouseWheel {
+            device_id: unsafe { std::mem::zeroed() },
+            delta: MouseScrollDelta::LineDelta(1.0, -1.0),
+            phase: TouchPhase::Moved,
+            modifiers: ModifiersState::empty(),
+        },
+    };
+    let ev = from_winit_event(&wheel_event).expect("mouse wheel");
+    assert_eq!(ev.event_type(), EventType::Motion2D);
+    assert_eq!(ev.source(), EventSource::Mouse);
+    let motion = unsafe { ev.motion2d() };
+    assert_eq!(motion, vec2(1.0, -1.0));
+
+    let focus_event = WEvent::WindowEvent {
+        window_id,
+        event: WindowEvent::Focused(true),
+    };
+    let ev = from_winit_event(&focus_event).expect("focused");
+    assert_eq!(ev.event_type(), EventType::Pressed);
+    assert_eq!(ev.source(), EventSource::Unknown);
+
+    let focus_event = WEvent::WindowEvent {
+        window_id,
+        event: WindowEvent::Focused(false),
+    };
+    let ev = from_winit_event(&focus_event).expect("unfocused");
+    assert_eq!(ev.event_type(), EventType::Released);
+    assert_eq!(ev.source(), EventSource::Unknown);
+
+    let device_id: winit::event::DeviceId = unsafe { std::mem::zeroed() };
+
+    let button_event = WEvent::DeviceEvent {
+        device_id,
+        event: DeviceEvent::Button {
+            button: 1,
+            state: ElementState::Pressed,
+        },
+    };
+    let ev = from_winit_event(&button_event).expect("gamepad button");
+    assert_eq!(ev.event_type(), EventType::Pressed);
+    assert_eq!(ev.source(), EventSource::Gamepad);
+
+    let motion_event = WEvent::DeviceEvent {
+        device_id,
+        event: DeviceEvent::Motion { axis: 0, value: 0.5 },
+    };
+    let ev = from_winit_event(&motion_event).expect("gamepad motion");
+    assert_eq!(ev.event_type(), EventType::Joystick);
+    assert_eq!(ev.source(), EventSource::Gamepad);
+    let motion = unsafe { ev.motion2d() };
+    assert_eq!(motion, vec2(0.0, 0.5));
+
+    // Existing engine callback test
     if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
         return;
     }


### PR DESCRIPTION
## Summary
- support mouse wheel and focus changes in winit event conversion
- convert joystick/gamepad events into internal event types
- test conversions for new input events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e7af6ce98832aaed25508275efc48