### PR TITLE
Add release wrappers for render resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,8 @@ harness = false
 name = "scene"
 path = "tests/scene.rs"
 harness = false
+
+[[test]]
+name = "release"
+path = "tests/release.rs"
+harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,18 @@ pub extern "C" fn meshi_gfx_set_renderable_transform(
     unsafe { &mut *render }.set_mesh_object_transform(h, unsafe { &*transform });
 }
 
+/// Release a previously created mesh object handle.
+///
+/// # Safety
+/// `render` and `h` must be valid pointers.
+#[no_mangle]
+pub extern "C" fn meshi_gfx_release_mesh_object(
+    render: *mut RenderEngine,
+    h: *const Handle<MeshObject>,
+) {
+    unsafe { &mut *render }.release_mesh_object(unsafe { *h });
+}
+
 /// Create a directional light for the scene.
 ///
 /// # Safety
@@ -233,6 +245,18 @@ pub extern "C" fn meshi_gfx_set_directional_light_transform(
     transform: *const Mat4,
 ) {
     unsafe { &mut *render }.set_directional_light_transform(h, unsafe { &*transform });
+}
+
+/// Release a directional light from the renderer.
+///
+/// # Safety
+/// `render` and `h` must be valid pointers.
+#[no_mangle]
+pub extern "C" fn meshi_gfx_release_directional_light(
+    render: *mut RenderEngine,
+    h: *const Handle<DirectionalLight>,
+) {
+    unsafe { &mut *render }.release_directional_light(unsafe { *h });
 }
 
 /// Set the world-to-camera transform used for rendering.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -143,6 +143,20 @@ impl RenderEngine {
         }
     }
 
+    pub fn release_directional_light(&mut self, handle: Handle<DirectionalLight>) {
+        self.directional_lights.release(handle);
+    }
+
+    pub fn has_directional_light(&self, handle: Handle<DirectionalLight>) -> bool {
+        self.directional_lights.get_ref(handle).is_some()
+    }
+
+    pub fn insert_dummy_directional_light(&mut self) -> Handle<DirectionalLight> {
+        self.directional_lights
+            .insert(DirectionalLight::default())
+            .unwrap()
+    }
+
     pub fn register_mesh_object(&mut self, info: &FFIMeshObjectInfo) -> Handle<MeshObject> {
         let info: MeshObjectInfo = info.into();
         let object = info
@@ -197,6 +211,18 @@ impl RenderEngine {
         //                self.scene.update_object_transform(*t, transform);
         //            }
         //        }
+    }
+
+    pub fn release_mesh_object(&mut self, handle: Handle<MeshObject>) {
+        self.mesh_objects.release(handle);
+    }
+
+    pub fn has_mesh_object(&self, handle: Handle<MeshObject>) -> bool {
+        self.mesh_objects.get_ref(handle).is_some()
+    }
+
+    pub fn insert_dummy_mesh_object(&mut self) -> Handle<MeshObject> {
+        self.mesh_objects.insert(MeshObject::default()).unwrap()
     }
 
     pub fn update(&mut self, _delta_time: f32) {
@@ -269,3 +295,4 @@ impl RenderEngine {
         Ok(())
     }
 }
+

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -42,9 +42,8 @@ fn main() {
     assert_eq!(out.rotation, new_status.rotation);
 
     unsafe {
+        meshi_gfx_release_mesh_object(render, &cube);
         meshi_physx_release_rigid_body(physics, &rb);
-    }
-    unsafe {
         meshi_destroy_engine(engine);
     }
 }

--- a/tests/release.rs
+++ b/tests/release.rs
@@ -1,0 +1,30 @@
+use meshi::render::{RenderEngine, RenderEngineInfo};
+use tempfile::tempdir;
+use std::fs;
+
+fn main() {
+    // Skip in headless environments similar to other tests.
+    if std::env::var("DISPLAY").is_err() && std::env::var("WAYLAND_DISPLAY").is_err() {
+        return;
+    }
+
+    let dir = tempdir().unwrap();
+    let db_dir = dir.path().join("database");
+    fs::create_dir_all(&db_dir).unwrap();
+    fs::write(db_dir.join("db.json"), "{}").unwrap();
+
+    let mut render = RenderEngine::new(&RenderEngineInfo {
+        application_path: dir.path().to_str().unwrap().into(),
+        scene_info: None,
+        headless: true,
+    });
+
+    let mesh = render.insert_dummy_mesh_object();
+    let light = render.insert_dummy_directional_light();
+    assert!(render.has_mesh_object(mesh));
+    assert!(render.has_directional_light(light));
+    render.release_mesh_object(mesh);
+    render.release_directional_light(light);
+    assert!(!render.has_mesh_object(mesh));
+    assert!(!render.has_directional_light(light));
+}


### PR DESCRIPTION
## Summary
- support releasing mesh objects and directional lights in render pools
- expose FFI helpers for releasing render resources
- test releasing graphics resources

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e7b2b2a38832aba2196e86761c9ee