### PR TITLE
Load scene assets in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "gltf",
  "image 0.24.9",
  "koji",
+ "rayon",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ gltf = "1.4.1"  # For reading glTF files
 unzip3 = "1.0.0"
 base64 = "0.22.1"
 winit = "0.26"
+rayon = "1.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -44,6 +44,12 @@ pub struct Database {
 //    defaults: Defaults,
 }
 
+// The database wraps a raw pointer to the rendering context but loading models
+// and images only touches filesystem data structures. It is therefore safe to
+// send across threads as long as external synchronization (like a `Mutex`) is
+// used.
+unsafe impl Send for Database {}
+
 impl Database {
     pub fn base_path(&self) -> &str {
         &self.base_path

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_void, fmt};
+use std::{ffi::c_void, fmt, sync::{Arc, Mutex}};
 
 use dashi::{
     utils::{Handle, Pool},
@@ -6,7 +6,7 @@ use dashi::{
 };
 use database::{Database, Error as DatabaseError};
 use glam::{Mat4, Vec4};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo};
 pub mod config;
@@ -319,13 +319,46 @@ impl RenderEngine {
     /// database. Models and images that fail to load will return an error so
     /// callers can react accordingly.
     pub fn set_scene(&mut self, info: &SceneInfo) -> Result<(), database::Error> {
-        for m in info.models {
-            self.database.load_model(m)?;
+        let db = Arc::new(Mutex::new(&mut self.database));
+        let errors: Arc<Mutex<Vec<database::Error>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let models = info.models;
+        let images = info.images;
+
+        rayon::scope(|s| {
+            let db_clone = db.clone();
+            let err_clone = errors.clone();
+            s.spawn(move |_| {
+                for m in models {
+                    if let Err(e) = db_clone.lock().unwrap().load_model(m) {
+                        warn!("Failed to load model {}: {}", m, e);
+                        err_clone.lock().unwrap().push(e);
+                    }
+                }
+            });
+
+            let db_clone = db.clone();
+            let err_clone = errors.clone();
+            s.spawn(move |_| {
+                for i in images {
+                    if let Err(e) = db_clone.lock().unwrap().load_image(i) {
+                        warn!("Failed to load image {}: {}", i, e);
+                        err_clone.lock().unwrap().push(e);
+                    }
+                }
+            });
+        });
+
+        match Arc::try_unwrap(errors)
+            .unwrap()
+            .into_inner()
+            .unwrap()
+            .into_iter()
+            .next()
+        {
+            Some(e) => Err(e),
+            None => Ok(()),
         }
-        for i in info.images {
-            self.database.load_image(i)?;
-        }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- Parallelize scene loading using Rayon tasks
- Mark render database as `Send` to allow cross-thread access
- Add Rayon dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e86f62bd0832a9940e7638513be5b