### PR TITLE
Refactor resource loaders and add tests

### DIFF
--- a/src/render/database/geometry.rs
+++ b/src/render/database/geometry.rs
@@ -1,594 +1,75 @@
-//use dashi::{utils::Handle, BufferInfo, Context};
-//use glam::{IVec4, Mat4, Quat, Vec2, Vec3, Vec4};
-//use miso::{Scene, Vertex};
-//use serde::{Deserialize, Serialize};
-//use tracing::debug;
-//
-//use super::{json, Database};
-//use std::{collections::HashMap, fs};
-//#[derive(Debug, Clone)]
-//pub struct Joint {
-//    pub name: String,
-//    pub node_index: usize,
-//    pub inverse_bind_matrix: Mat4,
-//}
-//
-//#[derive(Debug, Clone)]
-//pub struct Skeleton {
-//    pub joints: Vec<Joint>,
-//}
-//
-//#[derive(Debug, Clone)]
-//pub struct Keyframe {
-//    pub time: f32,
-//    pub translation: Vec3,
-//    pub rotation: Quat,
-//    pub scale: Vec3,
-//}
-//
-//#[derive(Debug, Clone)]
-//pub struct BoneAnimation {
-//    pub bone_name: String,
-//    pub keyframes: Vec<Keyframe>,
-//}
-//
-//#[derive(Debug, Clone)]
-//pub struct Animation {
-//    pub name: String,
-//    pub bones: Vec<BoneAnimation>,
-//}
-//
-//#[derive(Debug, Clone)]
-//pub struct AnimationSet {
-//    pub animations: Vec<Animation>,
-//}
-//
-//#[derive(Default, Clone)]
-//pub struct SubmeshResource {
-//    pub m: Handle<miso::Mesh>,
-//    pub mat: Handle<miso::Material>,
-//}
-//
-//#[derive(Default, Clone)]
-//pub struct MeshResource {
-//    pub name: String,
-//    pub submeshes: Vec<SubmeshResource>,
-//}
-//
-//#[derive(Default, Clone)]
-//pub struct ModelResource {
-//    pub meshes: Vec<MeshResource>,
-//}
-//pub struct GeometryResource {
-//    pub cfg: json::GeometryEntry,
-//    pub loaded: Option<ModelResource>,
-//}
-//
-//impl GeometryResource {
-//    pub fn load(
-//        &mut self,
-//        base_path: &str,
-//        ctx: &mut Context,
-//        scene: &mut Scene,
-//        db: &mut Database,
-//    ) {
-//        let file = format!("{}/{}", base_path, self.cfg.path);
-//
-//        let mut meshes = Vec::new();
-//        if let Some((gltf, skeleton, anim)) = load_gltf_model(&file, db) {
-//            for mesh in gltf.meshes {
-//                let mut submeshes = Vec::new();
-//                for (idx, submesh) in mesh.sub_meshes.iter().enumerate() {
-//                    let name = format!("{}.{}[{}]", self.cfg.name, mesh.name, idx);
-//                    debug!("Loading Mesh {}...", &name);
-//                    let vertices = ctx
-//                        .make_buffer(&BufferInfo {
-//                            debug_name: &format!("{} Vertices", name),
-//                            byte_size: (std::mem::size_of::<miso::Vertex>()
-//                                * submesh.vertices.len())
-//                                as u32,
-//                            visibility: dashi::MemoryVisibility::Gpu,
-//                            usage: dashi::BufferUsage::VERTEX,
-//                            initial_data: Some(unsafe {
-//                                submesh.vertices.as_slice().align_to::<u8>().1
-//                            }),
-//                        })
-//                        .unwrap();
-//
-//                    let indices = ctx
-//                        .make_buffer(&BufferInfo {
-//                            debug_name: &format!("{} Indices", name),
-//                            byte_size: (std::mem::size_of::<u32>() * submesh.indices.len()) as u32,
-//                            visibility: dashi::MemoryVisibility::Gpu,
-//                            usage: dashi::BufferUsage::INDEX,
-//                            initial_data: Some(unsafe {
-//                                submesh.indices.as_slice().align_to::<u8>().1
-//                            }),
-//                        })
-//                        .unwrap();
-//
-//                    let base_color = submesh
-//                        .material
-//                        .textures
-//                        .get(&TextureType::Diffuse)
-//                        .unwrap_or(&"[NOT FOUND]".to_string())
-//                        .clone();
-//                    let normal = submesh
-//                        .material
-//                        .textures
-//                        .get(&TextureType::Normal)
-//                        .unwrap_or(&"[NOT FOUND]".to_string())
-//                        .clone();
-//                    let emissive = submesh
-//                        .material
-//                        .textures
-//                        .get(&TextureType::Emissive)
-//                        .unwrap_or(&"[NOT FOUND]".to_string())
-//                        .clone();
-//
-//                    debug!(
-//                        "Attempting to load material {}.{} Textures:
-//                      -- Base Color : {}
-//                      -- Normal: {},
-//                      -- Emissive: {}",
-//                        name, submesh.material.name, base_color, normal, emissive
-//                    );
-//
-//                    let mat_info = miso::MaterialInfo {
-//                        name: submesh.material.name.clone(),
-//                        passes: vec!["ALL".to_string()],
-//                        base_color: db.fetch_texture(&base_color).unwrap_or_default(),
-//                        normal: db.fetch_texture(&normal).unwrap_or_default(),
-//                        emissive: db.fetch_texture(&emissive).unwrap_or_default(),
-//                        base_color_factor: submesh.material.base_color_factor,
-//                        emissive_factor: submesh.material.emissive_factor,
-//                    };
-//
-//                    debug!("Registering Mesh Material {}", &name);
-//                    let mat = scene.register_material(&mat_info);
-//                    db.insert_material(&name, mat);
-//
-//                    debug!("Registering Mesh {}", &name);
-//                    let m = scene.register_mesh(&miso::MeshInfo {
-//                        name: self.cfg.name.clone(),
-//                        vertices,
-//                        num_vertices: submesh.vertices.len(),
-//                        indices,
-//                        num_indices: submesh.indices.len(),
-//                    });
-//
-//                    submeshes.push(SubmeshResource { m, mat });
-//                }
-//                meshes.push(MeshResource {
-//                    name: mesh.name.clone(),
-//                    submeshes,
-//                });
-//            }
-//            self.loaded = Some(ModelResource { meshes });
-//        } else {
-//            debug!("Failed to load {}!", self.cfg.name);
-//        }
-//    }
-//
-//    pub fn unload(&mut self) {
-//        self.loaded = None;
-//    }
-//}
-//
-//impl From<json::Geometry> for HashMap<String, GeometryResource> {
-//    fn from(value: json::Geometry) -> Self {
-//        let mut v = HashMap::new();
-//        for geometry in value.geometry {
-//            v.insert(
-//                geometry.name.clone(),
-//                GeometryResource {
-//                    cfg: geometry,
-//                    loaded: None,
-//                },
-//            );
-//        }
-//
-//        v
-//    }
-//}
-//
-//pub fn load_db_geometries(base_path: &str, cfg: &json::Database) -> Option<json::Geometry> {
-//    match &cfg.geometry {
-//        Some(path) => {
-//            let rpath = format!("{}/{}", base_path, path);
-//            debug!("Found geometry path {}", &rpath);
-//            match fs::read_to_string(&rpath) {
-//                Ok(json_data) => {
-//                    debug!("Loaded geometry database registry {}!", &rpath);
-//                    let info: json::Geometry = serde_json::from_str(&json_data).unwrap();
-//                    return Some(info);
-//                }
-//                Err(_) => return None,
-//            }
-//        }
-//        None => return None,
-//    };
-//}
-//
-//#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize)]
-//pub enum TextureType {
-//    Diffuse,
-//    Specular,
-//    Roughness,
-//    Normal,
-//    Occlusion,
-//    Emissive,
-//    Albedo,
-//}
-//
-//#[derive(Debug, Clone)]
-//struct Material {
-//    pub name: String,
-//    pub emissive_factor: Vec4,
-//    pub base_color_factor: Vec4,
-//    pub textures: HashMap<TextureType, String>,
-//}
-//
-//#[derive(Debug, Clone)]
-//struct Submesh {
-//    pub vertices: Vec<Vertex>,
-//    pub indices: Vec<Index>,
-//    pub material: Material,
-//}
-//
-//type Index = u32;
-//#[derive(Debug, Clone)]
-//struct Mesh {
-//    pub name: String,
-//    pub sub_meshes: Vec<Submesh>,
-//}
-//
-//#[derive(Debug, Clone)]
-//struct Model {
-//    pub meshes: Vec<Mesh>,
-//}
-//
-//fn build_parent_map(gltf: &gltf::Document) -> HashMap<usize, usize> {
-//    let mut parent_map = HashMap::new();
-//
-//    for scene in gltf.scenes() {
-//        for node in scene.nodes() {
-//            for child in node.children() {
-//                parent_map.insert(child.index(), node.index());
-//            }
-//        }
-//    }
-//
-//    parent_map
-//}
-//
-//fn compute_node_transform(node: &gltf::Node) -> Mat4 {
-//    let transform = node.transform();
-//    match transform {
-//        gltf::scene::Transform::Matrix { matrix } => {
-//            Mat4::from_cols_array_2d(&matrix) // Directly use provided matrix
-//        }
-//        gltf::scene::Transform::Decomposed {
-//            translation,
-//            rotation,
-//            scale,
-//        } => {
-//            let translation_matrix = Mat4::from_translation(Vec3::from(translation));
-//            let rotation_matrix = Mat4::from_quat(Quat::from_array(rotation));
-//            let scale_matrix = Mat4::from_scale(Vec3::from(scale));
-//
-//            translation_matrix * rotation_matrix * scale_matrix
-//        }
-//    }
-//}
-//
-//fn compute_global_transform(
-//    node: &gltf::Node,
-//    parent_map: &HashMap<usize, usize>,
-//    gltf: &gltf::Document,
-//) -> Mat4 {
-//    let mut transform = compute_node_transform(node);
-//    let mut current = node.index();
-//
-//    // Walk up the hierarchy using the parent map
-//    while let Some(&parent_index) = parent_map.get(&current) {
-//        if let Some(parent_node) = gltf.nodes().nth(parent_index) {
-//            transform = compute_node_transform(&parent_node) * transform;
-//            current = parent_index;
-//        } else {
-//            break;
-//        }
-//    }
-//
-//    transform
-//}
-//
-//fn transform_vertex(position: [f32; 3], transform: &Mat4) -> [f32; 3] {
-//    let pos_vec = *transform * Vec4::new(position[0], position[1], position[2], 1.0);
-//    [pos_vec.x, pos_vec.y, pos_vec.z]
-//}
-//
-//#[allow(dead_code)]
-//fn load_gltf_model(
-//    path: &str,
-//    db: &mut Database,
-//) -> Option<(Model, Option<Skeleton>, Option<AnimationSet>)> {
-//    debug!("Loading Model {}", path);
-//    let (gltf, buffers, _images) = gltf::import(path).expect("Failed to load glTF file");
-//    let mut meshes = Vec::new();
-//    let mut _mesh_name = String::new();
-//    let parent_map = build_parent_map(&gltf);
-//    for node in gltf.nodes() {
-//        let _global_transform = compute_node_transform(&node);
-//        if let Some(mesh) = node.mesh() {
-//            let mut submeshes = Vec::new();
-//            let global_transform = compute_global_transform(&node, &parent_map, &gltf);
-//            _mesh_name = mesh.name().unwrap_or("[UNKNOWN]").to_string();
-//            debug!("Loading Mesh {}", _mesh_name);
-//            for primitive in mesh.primitives() {
-//                let mut vertices = Vec::new();
-//                let mut indices = Vec::new();
-//                let mut _material = None;
-//
-//                let reader = primitive.reader(|buffer| Some(&buffers[buffer.index()]));
-//
-//                let mut bone_ids: Vec<[u16; 4]> = Vec::new();
-//                let mut bone_weights: Vec<[f32; 4]> = Vec::new();
-//
-//                // Extract Positions
-//                let positions: Vec<[f32; 3]> = reader
-//                    .read_positions()?
-//                    .map(|pos| transform_vertex(pos, &global_transform))
-//                    .collect();
-//
-//                // Extract Normals
-//                let normals: Vec<[f32; 3]> = reader.read_normals()?.collect();
-//
-//                // Extract Texture Coordinates
-//                let tex_coords: Vec<[f32; 2]> = reader.read_tex_coords(0)?.into_f32().collect();
-//
-//                let colors: Vec<[f32; 4]> = if let Some(colors) = reader.read_colors(0) {
-//                    colors.into_rgba_f32().collect()
-//                } else {
-//                    let f = [0.0, 0.0, 0.0, 1.0];
-//                    vec![f; tex_coords.len()]
-//                };
-//
-//                // Extract Bone Weights
-//                if let Some(joints) = reader.read_joints(0) {
-//                    bone_ids = joints.into_u16().collect();
-//                } else {
-//                    bone_ids.resize(positions.len(), [0, 0, 0, 0]);
-//                }
-//
-//                if let Some(weights) = reader.read_weights(0) {
-//                    bone_weights = weights.into_f32().collect();
-//                } else {
-//                    bone_weights.resize(positions.len(), [0.0, 0.0, 0.0, 0.0]);
-//                }
-//
-//                let joint_ids: Vec<[i32; 4]> = bone_ids
-//                    .iter()
-//                    .map(|a| return [a[0] as i32, a[1] as i32, a[2] as i32, a[3] as i32])
-//                    .collect();
-//
-//                // Collect vertex data
-//                for i in 0..positions.len() {
-//                    vertices.push(Vertex {
-//                        position: (Vec3::from(positions[i]), 1.0).into(),
-//                        normal: (Vec3::from(normals[i]), 1.0).into(),
-//                        color: (Vec4::from(colors[i])),
-//                        tex_coords: Vec2::from(tex_coords[i]),
-//                        joint_ids: IVec4::from(joint_ids[i]),
-//                        joints: Vec4::from(bone_weights[i]),
-//                    });
-//                }
-//
-//                // Extract Indices
-//                if let Some(indices_data) = reader.read_indices() {
-//                    indices.extend(indices_data.into_u32());
-//                }
-//
-//                let mut mat_name = "Unknown".to_string();
-//                // Extract Material Information
-//                let mat = primitive.material();
-//                {
-//                    if let Some(name) = mat.name() {
-//                        mat_name = name.to_string();
-//                    }
-//
-//                    let mut textures = HashMap::new();
-//                    const CUSTOM_ENGINE: engine::GeneralPurpose =
-//                        engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
-//
-//                    use base64::{
-//                        alphabet,
-//                        engine::{self, general_purpose},
-//                        Engine as _,
-//                    };
-//                    let mut process_texture_func = |tex: gltf::texture::Texture, name, kind| {
-//                        let tex_name = format!("{}.{}[{}]", _mesh_name, name, submeshes.len());
-//                        match tex.source().source() {
-//                            gltf::image::Source::View { view, mime_type: _ } => {
-//                                let buffer = &buffers[view.buffer().index()];
-//                                let start = view.offset();
-//                                let end = start + view.length();
-//                                let img_bytes = &buffer[start..end];
-//
-//                                db.register_texture_from_bytes(&tex_name, &img_bytes);
-//                            }
-//                            gltf::image::Source::Uri { uri, mime_type: _ } => {
-//                                if uri.starts_with("data:") {
-//                                    if let Some((_, base64_data)) = uri.split_once(";base64,") {
-//                                        let data = base64::engine::general_purpose::STANDARD
-//                                            .decode(base64_data)
-//                                            .unwrap();
-//                                        db.register_texture_from_bytes(&tex_name, &data);
-//                                    }
-//                                } else {
-//                                    tex.source().source();
-//                                    let path = format!("{}/{}", db.base_path(), uri);
-//                                    let data = std::fs::read(path).unwrap();
-//                                    db.register_texture_from_bytes(&tex_name, &data);
-//                                }
-//                            }
-//                        }
-//
-//                        textures.insert(kind, tex_name);
-//                    };
-//
-//                    if let Some(info) = mat.pbr_metallic_roughness().base_color_texture() {
-//                        process_texture_func(info.texture(), "BASE_COLOR", TextureType::Diffuse);
-//                    }
-//
-//                    if let Some(info) = mat.emissive_texture() {
-//                        process_texture_func(info.texture(), "EMISSIVE", TextureType::Emissive);
-//                    }
-//
-//                    if let Some(info) = mat.normal_texture() {
-//                        process_texture_func(info.texture(), "NORMAL", TextureType::Normal);
-//                    }
-//
-//                    if let Some(info) = mat.occlusion_texture() {
-//                        process_texture_func(info.texture(), "OCCLUSION", TextureType::Occlusion);
-//                    }
-//
-//                    debug!(
-//                        "REGISTERING MATERIAL NAME : {}.{} with texture len [{}]",
-//                        _mesh_name,
-//                        mat_name,
-//                        textures.len()
-//                    );
-//                    _material = Some(Material {
-//                        name: mat_name,
-//                        textures,
-//                        emissive_factor: Vec4::from((Vec3::from_array(mat.emissive_factor()), 1.0)),
-//                        base_color_factor: Vec4::from_array(
-//                            mat.pbr_metallic_roughness().base_color_factor(),
-//                        ),
-//                    });
-//
-//                    submeshes.push(Submesh {
-//                        vertices,
-//                        indices,
-//                        material: _material.unwrap(),
-//                    });
-//                }
-//            }
-//
-//            meshes.push(Mesh {
-//                name: mesh.name().unwrap_or("None").to_string(),
-//                sub_meshes: submeshes,
-//            });
-//        }
-//    }
-//    let mut joints = Vec::new();
-//
-//    if let Some(skin) = gltf.skins().next() {
-//        let reader = skin.reader(|buffer| Some(&buffers[buffer.index()]));
-//        let inverse_bind_matrices: Vec<Mat4> = reader
-//            .read_inverse_bind_matrices()
-//            .unwrap()
-//            .map(|m| Mat4::from_cols_array_2d(&m))
-//            .collect();
-//
-//        for (i, joint) in skin.joints().enumerate() {
-//            let name = joint.name().unwrap_or("[UNNAMED]").to_string();
-//            joints.push(Joint {
-//                name,
-//                node_index: joint.index(),
-//                inverse_bind_matrix: inverse_bind_matrices
-//                    .get(i)
-//                    .cloned()
-//                    .unwrap_or(Mat4::IDENTITY),
-//            });
-//        }
-//    }
-//
-//    let skeleton_opt = if !joints.is_empty() {
-//        Some(Skeleton { joints })
-//    } else {
-//        None
-//    };
-//
-//    let mut animations = Vec::new();
-//
-//    for anim in gltf.animations() {
-//        let name = anim.name().unwrap_or("Unnamed").to_string();
-//        let mut bones = Vec::new();
-//
-//        for channel in anim.channels() {
-//            let target = channel.target();
-//            let node = target.node();
-//            let bone_name = node.name().unwrap_or("[NO NAME]").to_string();
-//
-//            let reader = channel.reader(|buffer| Some(&buffers[buffer.index()]));
-//            let times: Vec<f32> = reader.read_inputs().unwrap().collect();
-//
-//            let mut keyframes = Vec::new();
-//
-//            match (channel.target().property(), reader.read_outputs().unwrap()) {
-//                (
-//                    gltf::animation::Property::Translation,
-//                    gltf::animation::util::ReadOutputs::Translations(translations),
-//                ) => {
-//                    for (t, i) in translations.zip(times.iter()) {
-//                        let [x, y, z] = t;
-//                        keyframes.push(Keyframe {
-//                            time: *i,
-//                            translation: Vec3::new(x, y, z),
-//                            rotation: Quat::IDENTITY,
-//                            scale: Vec3::ONE,
-//                        });
-//                    }
-//                }
-//                (
-//                    gltf::animation::Property::Rotation,
-//                    gltf::animation::util::ReadOutputs::Rotations(rotations),
-//                ) => {
-//                    for (r, i) in rotations.into_f32().zip(times.iter()) {
-//                        let [x, y, z, w] = r;
-//                        keyframes.push(Keyframe {
-//                            time: *i,
-//                            translation: Vec3::ZERO,
-//                            rotation: Quat::from_array([x, y, z, w]),
-//                            scale: Vec3::ONE,
-//                        });
-//                    }
-//                }
-//                (
-//                    gltf::animation::Property::Scale,
-//                    gltf::animation::util::ReadOutputs::Scales(scales),
-//                ) => {
-//                    for (s, i) in scales.zip(times.iter()) {
-//                        let [x, y, z] = s;
-//                        keyframes.push(Keyframe {
-//                            time: *i,
-//                            translation: Vec3::ZERO,
-//                            rotation: Quat::IDENTITY,
-//                            scale: Vec3::new(x, y, z),
-//                        });
-//                    }
-//                }
-//                _ => {}
-//            }
-//
-//            if !keyframes.is_empty() {
-//                bones.push(BoneAnimation {
-//                    bone_name,
-//                    keyframes,
-//                });
-//            }
-//        }
-//
-//        animations.push(Animation { name, bones });
-//    }
-//
-//    let animation_set_opt = if animations.is_empty() {
-//        None
-//    } else {
-//        Some(AnimationSet { animations })
-//    };
-//
-//    Some((Model { meshes }, skeleton_opt, animation_set_opt))
-//}
+use std::collections::HashMap;
+use std::path::Path;
+
+use gltf::Gltf;
+
+use super::{geometry_primitives, MeshResource};
+use dashi::Context;
+
+/// Load the default set of mesh primitives into a map keyed by their names.
+///
+/// The database uses this during initialization so tests can rely on a small
+/// library of meshes (triangle, cube and sphere) without hitting the file
+/// system.
+pub fn load_primitives(ctx: &mut Context) -> HashMap<String, MeshResource> {
+    let mut geometry = HashMap::new();
+    geometry.insert(
+        "MESHI_TRIANGLE".to_string(),
+        geometry_primitives::make_triangle(&Default::default(), ctx),
+    );
+    geometry.insert(
+        "MESHI_CUBE".to_string(),
+        geometry_primitives::make_cube(&Default::default(), ctx),
+    );
+    geometry.insert(
+        "MESHI_SPHERE".to_string(),
+        geometry_primitives::make_sphere(&Default::default(), ctx),
+    );
+    geometry
+}
+
+/// Parse a glTF file from disk and return its document.
+///
+/// The helper consolidates error handling and provides a single place for
+/// future glTF related extensions.
+pub fn parse_gltf<P: AsRef<Path>>(path: P) -> gltf::Result<Gltf> {
+    Gltf::open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_gltf;
+    use std::fs;
+    use tempfile::tempdir;
+
+    // Build a minimal glTF asset containing a single triangle primitive and
+    // ensure the parser succeeds.
+    #[test]
+    fn parse_triangle_gltf() {
+        let dir = tempdir().unwrap();
+        let bin_path = dir.path().join("data.bin");
+        // Positions for three vertices followed by indices 0,1,2
+        let mut bin = Vec::new();
+        for f in [
+            0.0f32, 0.0, 0.0, // v0
+            1.0, 0.0, 0.0, // v1
+            0.0, 1.0, 0.0, // v2
+        ] {
+            bin.extend_from_slice(&f.to_le_bytes());
+        }
+        for i in [0u16, 1, 2] {
+            bin.extend_from_slice(&i.to_le_bytes());
+        }
+        fs::write(&bin_path, &bin).unwrap();
+
+        let gltf = format!(
+            "{{\n  \"asset\": {{ \"version\": \"2.0\" }},\n  \"scenes\": [{{ \"nodes\": [0] }}],\n  \"scene\": 0,\n  \"nodes\": [{{ \"mesh\": 0 }}],\n  \"meshes\": [{{ \"primitives\": [{{ \"attributes\": {{ \"POSITION\": 0 }}, \"indices\": 1 }}] }}],\n  \"buffers\": [{{ \"uri\": \"data.bin\", \"byteLength\": {} }}],\n  \"bufferViews\": [{{ \"buffer\": 0, \"byteOffset\": 0, \"byteLength\": 36 }}, {{ \"buffer\": 0, \"byteOffset\": 36, \"byteLength\": 6 }}],\n  \"accessors\": [{{ \"bufferView\": 0, \"componentType\": 5126, \"count\": 3, \"type\": \"VEC3\", \"min\": [0.0,0.0,0.0], \"max\": [1.0,1.0,0.0] }}, {{ \"bufferView\": 1, \"componentType\": 5123, \"count\": 3, \"type\": \"SCALAR\" }}]\n}}",
+            bin.len()
+        );
+        let gltf_path = dir.path().join("scene.gltf");
+        fs::write(&gltf_path, gltf).unwrap();
+
+        let doc = parse_gltf(&gltf_path).unwrap();
+        assert_eq!(doc.meshes().len(), 1);
+    }
+}

--- a/src/render/database/images.rs
+++ b/src/render/database/images.rs
@@ -1,327 +1,41 @@
-use dashi::utils::Handle;
-use dashi::Context;
-use dashi::ImageInfo;
-use dashi::ImageViewInfo;
-use dashi::SamplerInfo;
-use image::ImageBuffer;
-use image::Rgba;
-//use miso::Scene;
-//use miso::TextureInfo;
-//use tracing::debug;
-//use tracing::info;
-//
-//use super::json;
-//use super::TTFont;
-//use std::collections::HashMap;
-//use std::fs;
-//
-//#[derive(Default)]
-//pub struct ImageResource {
-//    pub cfg: json::ImageEntry,
-//    pub loaded: Option<Handle<miso::Texture>>,
-//}
-//
-//impl ImageResource {
-//    pub fn load_default_image(ctx: &mut Context, scene: &mut Scene) -> Handle<miso::Texture> {
-//        // Define the size of the image
-//        const WIDTH: u32 = 512;
-//        const HEIGHT: u32 = 512;
-//        const CHECKER_SIZE: u32 = 64;
-//
-//        // Create an ImageBuffer for the checkered pattern
-//        let mut img = ImageBuffer::new(WIDTH, HEIGHT);
-//
-//        for y in 0..HEIGHT {
-//            for x in 0..WIDTH {
-//                // Determine the color based on the checker pattern
-//                let is_light = ((x / CHECKER_SIZE) + (y / CHECKER_SIZE)) % 2 == 0;
-//                let color = if is_light {
-//                    Rgba([200, 50, 200, 255]) // Light gray
-//                } else {
-//                    Rgba([50, 15, 50, 255]) // Dark gray
-//                };
-//
-//                img.put_pixel(x, y, color);
-//            }
-//        }
-//
-//        // Convert the image to RGBA8 format
-//        let rgba_image = img;
-//
-//        let (width, height) = rgba_image.dimensions();
-//        let bytes = rgba_image.into_raw();
-//        assert!((width * height * 4) as usize == bytes.len());
-//
-//        let img = ctx
-//            .make_image(&ImageInfo {
-//                debug_name: "default_checkered",
-//                dim: [width, height, 1],
-//                layers: 1,
-//                format: dashi::Format::RGBA8,
-//                mip_levels: 1,
-//                initial_data: Some(&bytes),
-//            })
-//            .unwrap();
-//
-//        let view = ctx
-//            .make_image_view(&ImageViewInfo {
-//                debug_name: "default_checkered",
-//                img,
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        let sampler = ctx
-//            .make_sampler(&SamplerInfo {
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        info!("Registering default texture..");
-//        return scene.register_texture(&TextureInfo {
-//            image: img,
-//            view,
-//            sampler,
-//            dim: [width, height],
-//        });
-//    }
-//
-//    pub fn load_from_uri(
-//        name: &str,
-//        bytes: &[u8],
-//        ctx: &mut Context,
-//        scene: &mut Scene,
-//    ) -> Handle<miso::Texture> {
-//        let img = image::load_from_memory(bytes).unwrap();
-//        // Convert the image to RGBA8 format
-//        let rgba_image = img.to_rgba8();
-//
-//        let (width, height) = rgba_image.dimensions();
-//        let bytes = rgba_image.into_raw();
-//        assert!((width * height * 4) as usize == bytes.len());
-//
-//        let img = ctx
-//            .make_image(&ImageInfo {
-//                debug_name: name,
-//                dim: [width, height, 1],
-//                layers: 1,
-//                format: dashi::Format::RGBA8,
-//                mip_levels: 1,
-//                initial_data: Some(&bytes),
-//            })
-//            .unwrap();
-//
-//        let view = ctx
-//            .make_image_view(&ImageViewInfo {
-//                debug_name: name,
-//                img,
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        let sampler = ctx
-//            .make_sampler(&SamplerInfo {
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        debug!("Registering URI texture {}..", name);
-//        return scene.register_texture(&TextureInfo {
-//            image: img,
-//            view,
-//            sampler,
-//            dim: [width, height],
-//        });
-//    }
-//
-//    pub fn load_from_gltf(
-//        name: &str,
-//        data: &gltf::image::Data,
-//        ctx: &mut Context,
-//        scene: &mut Scene,
-//    ) -> Handle<miso::Texture> {
-//        // Define the size of the image
-//
-//        let width = data.width;
-//        let height = data.height;
-//        let bytes = &data.pixels;
-//        let format = match data.format {
-//            gltf::image::Format::R8 => dashi::Format::R8Sint,
-//            gltf::image::Format::R8G8B8A8 => dashi::Format::RGBA8,
-//            gltf::image::Format::R32G32B32A32FLOAT => dashi::Format::RGBA32F,
-//            _ => todo!(),
-//        };
-//
-//        let img = ctx
-//            .make_image(&ImageInfo {
-//                debug_name: name,
-//                dim: [width, height, 1],
-//                layers: 1,
-//                format,
-//                mip_levels: 1,
-//                initial_data: Some(&bytes),
-//            })
-//            .unwrap();
-//
-//        let view = ctx
-//            .make_image_view(&ImageViewInfo {
-//                debug_name: name,
-//                img,
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        let sampler = ctx
-//            .make_sampler(&SamplerInfo {
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        debug!("Registering embedded GLTF model texture {}..", name);
-//        return scene.register_texture(&TextureInfo {
-//            image: img,
-//            view,
-//            sampler,
-//            dim: [width, height],
-//        });
-//    }
-//
-//    pub fn load_rgba8(&mut self, base_path: &str, ctx: &mut Context, scene: &mut Scene) {
-//        let path = &format!("{}/{}", base_path, self.cfg.path.as_str());
-//        let img = image::open(&path).unwrap_or_default();
-//
-//        // Convert the image to RGBA8 format
-//        let rgba_image = img.to_rgba8();
-//
-//        // Flip the image vertically (upside down)
-//        //    let rgba_image = image::imageops::flip_vertical(&rgba_image);
-//
-//        let (width, height) = rgba_image.dimensions();
-//        let bytes = rgba_image.into_raw();
-//        assert!((width * height * 4) as usize == bytes.len());
-//
-//        let img = ctx
-//            .make_image(&ImageInfo {
-//                debug_name: &self.cfg.name,
-//                dim: [width, height, 1],
-//                layers: 1,
-//                format: dashi::Format::RGBA8,
-//                mip_levels: 1,
-//                initial_data: Some(&bytes),
-//            })
-//            .unwrap();
-//
-//        let view = ctx
-//            .make_image_view(&ImageViewInfo {
-//                debug_name: &self.cfg.name,
-//                img,
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        let sampler = ctx
-//            .make_sampler(&SamplerInfo {
-//                ..Default::default()
-//            })
-//            .unwrap();
-//
-//        info!("Registering texture {}", self.cfg.name);
-//        self.loaded = Some(scene.register_texture(&TextureInfo {
-//            image: img,
-//            view,
-//            sampler,
-//            dim: [width, height],
-//        }));
-//    }
-//
-//    pub fn unload(&mut self) {
-//        self.loaded = None;
-//    }
-//}
-//
-//impl From<json::Image> for HashMap<String, ImageResource> {
-//    fn from(value: json::Image) -> Self {
-//        let mut v = HashMap::new();
-//        for p in value.images {
-//            v.insert(
-//                p.name.clone(),
-//                ImageResource {
-//                    cfg: p,
-//                    loaded: None,
-//                },
-//            );
-//        }
-//
-//        v
-//    }
-//}
-//
-//pub fn load_db_images(base_path: &str, cfg: &json::Database) -> Option<json::Image> {
-//    match &cfg.images {
-//        Some(path) => {
-//            let rpath = format!("{}/{}", base_path, path);
-//            let path = &rpath;
-//            debug!("Found image path {}", path);
-//            match fs::read_to_string(path) {
-//                Ok(json_data) => {
-//                    debug!("Loaded image database registry {}!", path);
-//                    let info: json::Image = serde_json::from_str(&json_data).unwrap();
-//                    return Some(info);
-//                }
-//                Err(_) => return None,
-//            }
-//        }
-//        None => return None,
-//    };
-//}
-//
-//pub struct FontResource {
-//    pub cfg: json::TTFEntry,
-//    pub loaded: Option<TTFont>,
-//}
-//
-//impl FontResource {
-//    pub fn load(&mut self, base_path: &str, typeset: &[char]) {
-//        self.loaded = Some(TTFont::new(
-//            &format!("{}/{}", base_path, self.cfg.path.as_str()),
-//            1280,
-//            1024,
-//            self.cfg.size as f32,
-//            typeset,
-//        ));
-//    }
-//
-//    pub fn unload(&mut self) {
-//        self.loaded = None;
-//    }
-//}
-//
-//impl From<json::TTF> for HashMap<String, FontResource> {
-//    fn from(value: json::TTF) -> Self {
-//        let mut v = HashMap::new();
-//        for p in value.fonts {
-//            v.insert(
-//                p.name.clone(),
-//                FontResource {
-//                    cfg: p,
-//                    loaded: None,
-//                },
-//            );
-//        }
-//
-//        v
-//    }
-//}
-//
-//pub fn load_db_ttfs(cfg: &json::Database) -> Option<json::TTF> {
-//    match &cfg.ttf {
-//        Some(path) => match fs::read_to_string(path) {
-//            Ok(json_data) => {
-//                let info: json::TTF = serde_json::from_str(&json_data).unwrap();
-//                return Some(info);
-//            }
-//            Err(_) => return None,
-//        },
-//        None => return None,
-//    };
-//}
+use std::path::Path;
+
+use image::{DynamicImage, ImageError};
+
+/// Decode an image from a file path.
+///
+/// The caller receives the fully decoded image so tests can inspect its
+/// dimensions or pixel data without involving any GPU resources.
+pub fn load_image_from_path<P: AsRef<Path>>(path: P) -> Result<DynamicImage, ImageError> {
+    image::open(path)
+}
+
+/// Decode an image from an in-memory byte slice.
+///
+/// This is useful when images are embedded in containers such as glTF files.
+pub fn load_image_from_bytes(bytes: &[u8]) -> Result<DynamicImage, ImageError> {
+    image::load_from_memory(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{GenericImageView, Rgba, RgbaImage};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_from_path_and_bytes() {
+        let dir = tempdir().unwrap();
+        let img_path = dir.path().join("test.png");
+        let img = RgbaImage::from_pixel(2, 2, Rgba([1, 2, 3, 4]));
+        img.save(&img_path).unwrap();
+
+        let from_path = load_image_from_path(&img_path).unwrap();
+        assert_eq!(from_path.dimensions(), (2, 2));
+
+        let bytes = fs::read(&img_path).unwrap();
+        let from_bytes = load_image_from_bytes(&bytes).unwrap();
+        assert_eq!(from_bytes.dimensions(), (2, 2));
+    }
+}

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -6,7 +6,7 @@ pub use error::*;
 pub mod json;
 use std::collections::HashMap;
 use std::fs;
-mod images;
+pub mod images;
 use images::*;
 mod material;
 use material::*;
@@ -139,19 +139,7 @@ impl Database {
 //            ..Default::default()
 //        });
 
-        let mut geometry = HashMap::new();
-        geometry.insert(
-            "MESHI_TRIANGLE".to_string(),
-            geometry_primitives::make_triangle(&Default::default(), ctx),
-        );
-        geometry.insert(
-            "MESHI_CUBE".to_string(),
-            geometry_primitives::make_cube(&Default::default(), ctx),
-        );
-        geometry.insert(
-            "MESHI_SPHERE".to_string(),
-            geometry_primitives::make_sphere(&Default::default(), ctx),
-        );
+        let geometry = load_primitives(ctx);
 
         let mut textures = HashMap::new();
         textures.insert("DEFAULT".to_string(), Some(Handle::default()));
@@ -203,8 +191,8 @@ impl Database {
     /// that it can be retrieved later by tests or callers.
     pub fn load_model(&mut self, name: &str) -> Result<()> {
         let path = format!("{}/{}", self.base_path, name);
-        // Ensure the file exists on disk.
-        fs::read(&path)?;
+        // Ensure the file exists and is valid glTF.
+        parse_gltf(&path).map_err(|e| e.to_string())?;
         // Register the model in the geometry map if not already present.
         self.geometry
             .entry(name.to_string())
@@ -225,7 +213,7 @@ impl Database {
             return Ok(());
         }
         let path = format!("{}/{}", self.base_path, name);
-        image::open(&path)?;
+        load_image_from_path(&path)?;
         self.textures.insert(name.to_string(), None);
         Ok(())
     }

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -18,8 +18,25 @@ fn main() {
     // Minimal db.json so Database::new succeeds.
     fs::write(db_dir.join("db.json"), "{}").unwrap();
 
-    // Dummy model file.
-    fs::write(db_dir.join("model.gltf"), b"test").unwrap();
+    // Create a minimal valid glTF model the database can parse.
+    let bin_path = db_dir.join("data.bin");
+    let mut bin = Vec::new();
+    for f in [
+        0.0f32, 0.0, 0.0, // v0
+        1.0, 0.0, 0.0, // v1
+        0.0, 1.0, 0.0, // v2
+    ] {
+        bin.extend_from_slice(&f.to_le_bytes());
+    }
+    for i in [0u16, 1, 2] {
+        bin.extend_from_slice(&i.to_le_bytes());
+    }
+    fs::write(&bin_path, &bin).unwrap();
+    let gltf = format!(
+        "{{\n  \"asset\": {{ \"version\": \"2.0\" }},\n  \"scenes\": [{{ \"nodes\": [0] }}],\n  \"scene\": 0,\n  \"nodes\": [{{ \"mesh\": 0 }}],\n  \"meshes\": [{{ \"primitives\": [{{ \"attributes\": {{ \"POSITION\": 0 }}, \"indices\": 1 }}] }}],\n  \"buffers\": [{{ \"uri\": \"data.bin\", \"byteLength\": {} }}],\n  \"bufferViews\": [{{ \"buffer\": 0, \"byteOffset\": 0, \"byteLength\": 36 }}, {{ \"buffer\": 0, \"byteOffset\": 36, \"byteLength\": 6 }}],\n  \"accessors\": [{{ \"bufferView\": 0, \"componentType\": 5126, \"count\": 3, \"type\": \"VEC3\", \"min\": [0.0,0.0,0.0], \"max\": [1.0,1.0,0.0] }}, {{ \"bufferView\": 1, \"componentType\": 5123, \"count\": 3, \"type\": \"SCALAR\" }}]\n}}",
+        bin.len()
+    );
+    fs::write(db_dir.join("model.gltf"), gltf).unwrap();
 
     // Dummy image file using the image crate.
     let img_path = db_dir.join("albedo.png");


### PR DESCRIPTION
## Summary
- factor primitive loading into `load_primitives` and centralize glTF parsing in `parse_gltf`
- provide standalone helpers for decoding images from files or memory
- integrate new helpers into the database and fix scene test model generation
- add unit tests for glTF parsing and image loading

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e86d2dac0832aad6181c6e3bc69b7