### PR TITLE
Add customizable primitive creation

### DIFF
--- a/examples/ffi_init.rs
+++ b/examples/ffi_init.rs
@@ -1,4 +1,5 @@
 use glam::Mat4;
+use meshi::render::database::geometry_primitives::CubePrimitiveInfo;
 use meshi::*;
 use std::ffi::CString;
 
@@ -7,10 +8,9 @@ fn main() {
     let loc = CString::new(".").unwrap();
     let engine = unsafe { meshi_make_engine_headless(app.as_ptr(), loc.as_ptr()) };
     let render = unsafe { meshi_get_graphics_system(engine) };
-    let cube = unsafe { meshi_gfx_create_cube(render) };
-    unsafe {
-        meshi_gfx_set_renderable_transform(render, cube, &Mat4::IDENTITY);
-    }
+    let info = CubePrimitiveInfo { size: 2.0 };
+    let cube = unsafe { meshi_gfx_create_cube_ex(render, &info) };
+    unsafe { meshi_gfx_set_renderable_transform(render, cube, &Mat4::IDENTITY) };
     unsafe {
         meshi_destroy_engine(engine);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,24 @@ pub extern "C" fn meshi_gfx_create_cube(render: *mut RenderEngine) -> Handle<Mes
 }
 
 #[no_mangle]
+pub extern "C" fn meshi_gfx_create_cube_ex(
+    render: *mut RenderEngine,
+    info: *const render::database::geometry_primitives::CubePrimitiveInfo,
+) -> Handle<MeshObject> {
+    unsafe { &mut *render }.create_cube_ex(unsafe { &*info })
+}
+
+#[no_mangle]
 pub extern "C" fn meshi_gfx_create_sphere(render: *mut RenderEngine) -> Handle<MeshObject> {
     unsafe { &mut *render }.create_sphere()
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_sphere_ex(
+    render: *mut RenderEngine,
+    info: *const render::database::geometry_primitives::SpherePrimitiveInfo,
+) -> Handle<MeshObject> {
+    unsafe { &mut *render }.create_sphere_ex(unsafe { &*info })
 }
 
 #[no_mangle]

--- a/src/render/database/geometry_primitives.rs
+++ b/src/render/database/geometry_primitives.rs
@@ -14,6 +14,7 @@ struct Vertex {
     color: Vec4,
 }
 
+#[repr(C)]
 pub struct CubePrimitiveInfo {
     pub size: f32,
 }
@@ -136,6 +137,7 @@ pub fn make_cube(info: &CubePrimitiveInfo, ctx: &mut dashi::Context) -> MeshReso
     }
 }
 
+#[repr(C)]
 pub struct TrianglePrimitiveInfo {
     pub size: f32,
 }
@@ -207,6 +209,7 @@ pub fn make_triangle(info: &TrianglePrimitiveInfo, ctx: &mut dashi::Context) -> 
     }
 }
 
+#[repr(C)]
 pub struct SpherePrimitiveInfo {
     pub radius: f32,
     pub segments: u32,

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -13,7 +13,7 @@ use material::*;
 pub mod geometry;
 use geometry::*;
 pub mod font;
-mod geometry_primitives;
+pub mod geometry_primitives;
 pub use font::*;
 
 #[derive(Default, Clone)]
@@ -27,8 +27,8 @@ pub struct MeshResource {
 
 #[allow(dead_code)]
 struct Defaults {
-//    image: Handle<koji::Texture>,
-//    material: Handle<koji::Material>,
+    //    image: Handle<koji::Texture>,
+    //    material: Handle<koji::Material>,
 }
 
 #[allow(dead_code)]
@@ -39,9 +39,9 @@ pub struct Database {
     /// Map of texture names to optionally loaded handles. If a handle is
     /// `None` the texture has been registered but not yet loaded.
     textures: HashMap<String, Option<Handle<koji::Texture>>>,
-//    materials: HashMap<String, Handle<miso::Material>>,
-//    fonts: HashMap<String, FontResource>,
-//    defaults: Defaults,
+    //    materials: HashMap<String, Handle<miso::Material>>,
+    //    fonts: HashMap<String, FontResource>,
+    //    defaults: Defaults,
 }
 
 impl Database {
@@ -49,95 +49,92 @@ impl Database {
         &self.base_path
     }
 
-    pub fn new(
-        base_path: &str,
-        ctx: &mut dashi::Context,
-    ) -> Result<Self> {
+    pub fn new(base_path: &str, ctx: &mut dashi::Context) -> Result<Self> {
         info!("Loading Database {}", format!("{}/db.json", base_path));
         let _json_data = fs::read_to_string(format!("{}/db.json", base_path))?;
-//        let info: json::Database = serde_json::from_str(&json_data)?;
-//
-//        let images_cfg = load_db_images(base_path, &info);
-//        let fonts_cfg = load_db_ttfs(&info);
-//        let geometry_cfg = load_db_geometries(base_path, &info);
-//        let material_cfg = load_db_materials(base_path, &info);
-//
-//        let images = match images_cfg {
-//            Some(cfg) => cfg.into(),
-//            None => HashMap::default(),
-//        };
-//
-//        let materials = match material_cfg {
-//            Some(cfg) => cfg.into(),
-//            None => HashMap::default(),
-//        };
-//
-//        let fonts = match fonts_cfg {
-//            Some(cfg) => cfg.into(),
-//            None => HashMap::default(),
-//        };
-//
-//        let mut geometry = match geometry_cfg {
-//            Some(cfg) => cfg.into(),
-//            None => HashMap::default(),
-//        };
+        //        let info: json::Database = serde_json::from_str(&json_data)?;
+        //
+        //        let images_cfg = load_db_images(base_path, &info);
+        //        let fonts_cfg = load_db_ttfs(&info);
+        //        let geometry_cfg = load_db_geometries(base_path, &info);
+        //        let material_cfg = load_db_materials(base_path, &info);
+        //
+        //        let images = match images_cfg {
+        //            Some(cfg) => cfg.into(),
+        //            None => HashMap::default(),
+        //        };
+        //
+        //        let materials = match material_cfg {
+        //            Some(cfg) => cfg.into(),
+        //            None => HashMap::default(),
+        //        };
+        //
+        //        let fonts = match fonts_cfg {
+        //            Some(cfg) => cfg.into(),
+        //            None => HashMap::default(),
+        //        };
+        //
+        //        let mut geometry = match geometry_cfg {
+        //            Some(cfg) => cfg.into(),
+        //            None => HashMap::default(),
+        //        };
 
-//        geometry.insert(
-//            "MESHI_TRIANGLE".to_string(),
-//            GeometryResource {
-//                cfg: json::GeometryEntry {
-//                    name: "MESHI".to_string(),
-//                    path: "".to_string(),
-//                },
-//                loaded: Some(geometry_primitives::make_triangle(
-//                    &Default::default(),
-//                    ctx,
-////                    scene,
-//                )),
-//            },
-//        );
-//
-//        geometry.insert(
-//            "MESHI_CUBE".to_string(),
-//            GeometryResource {
-//                cfg: json::GeometryEntry {
-//                    name: "MESHI".to_string(),
-//                    path: "".to_string(),
-//                },
-//                loaded: Some(geometry_primitives::make_cube(
-//                    &Default::default(),
-//                    ctx,
-//                    scene,
-//                )),
-//            },
-//        );
-//
-//        geometry.insert(
-//            "MESHI_SPHERE".to_string(),
-//            GeometryResource {
-//                cfg: json::GeometryEntry {
-//                    name: "MESHI".to_string(),
-//                    path: "".to_string(),
-//                },
-//                loaded: Some(geometry_primitives::make_sphere(
-//                    &Default::default(),
-//                    ctx,
-//                    scene,
-//                )),
-//            },
-//        );
-//
-//        let default_texture = ImageResource::load_default_image(ctx, scene);
-//
-//        info!("Registering default material..");
-//        let default_material = scene.register_material(&MaterialInfo {
-//            name: "DEFAULT".to_string(),
-//            //passes: vec!["ALL".to_string()],
-//            passes: vec!["non-transparent".to_string()],
-//            base_color: default_texture,
-//            normal: Default::default(),
-//            ..Default::default()
-//        });
+        //        geometry.insert(
+        //            "MESHI_TRIANGLE".to_string(),
+        //            GeometryResource {
+        //                cfg: json::GeometryEntry {
+        //                    name: "MESHI".to_string(),
+        //                    path: "".to_string(),
+        //                },
+        //                loaded: Some(geometry_primitives::make_triangle(
+        //                    &Default::default(),
+        //                    ctx,
+        ////                    scene,
+        //                )),
+        //            },
+        //        );
+        //
+        //        geometry.insert(
+        //            "MESHI_CUBE".to_string(),
+        //            GeometryResource {
+        //                cfg: json::GeometryEntry {
+        //                    name: "MESHI".to_string(),
+        //                    path: "".to_string(),
+        //                },
+        //                loaded: Some(geometry_primitives::make_cube(
+        //                    &Default::default(),
+        //                    ctx,
+        //                    scene,
+        //                )),
+        //            },
+        //        );
+        //
+        //        geometry.insert(
+        //            "MESHI_SPHERE".to_string(),
+        //            GeometryResource {
+        //                cfg: json::GeometryEntry {
+        //                    name: "MESHI".to_string(),
+        //                    path: "".to_string(),
+        //                },
+        //                loaded: Some(geometry_primitives::make_sphere(
+        //                    &Default::default(),
+        //                    ctx,
+        //                    scene,
+        //                )),
+        //            },
+        //        );
+        //
+        //        let default_texture = ImageResource::load_default_image(ctx, scene);
+        //
+        //        info!("Registering default material..");
+        //        let default_material = scene.register_material(&MaterialInfo {
+        //            name: "DEFAULT".to_string(),
+        //            //passes: vec!["ALL".to_string()],
+        //            passes: vec!["non-transparent".to_string()],
+        //            base_color: default_texture,
+        //            normal: Default::default(),
+        //            ..Default::default()
+        //        });
 
         let mut geometry = HashMap::new();
         geometry.insert(
@@ -163,34 +160,34 @@ impl Database {
             textures,
         };
 
- //       let ptr: *mut Database = &mut db;
+        //       let ptr: *mut Database = &mut db;
 
- //       // Models HAVE to be loaded before materials, as they add materials.
- //       for (_name, mut model) in geometry {
- //           debug!("Attempting to load model {}...", model.cfg.name);
- //           if model.loaded.is_none() {
- //               model.load(base_path, ctx, scene, unsafe { &mut *ptr });
- //           }
+        //       // Models HAVE to be loaded before materials, as they add materials.
+        //       for (_name, mut model) in geometry {
+        //           debug!("Attempting to load model {}...", model.cfg.name);
+        //           if model.loaded.is_none() {
+        //               model.load(base_path, ctx, scene, unsafe { &mut *ptr });
+        //           }
 
- //           if let Some(m) = model.loaded {
- //               debug!("Success!");
- //               for mesh in m.meshes {
- //                   debug!("Making mesh {}.{} available", model.cfg.name, mesh.name);
- //                   db.geometry
- //                       .insert(format!("{}.{}", model.cfg.name, mesh.name), mesh);
- //               }
- //           } else {
- //               debug!("Failed!");
- //           }
- //       }
+        //           if let Some(m) = model.loaded {
+        //               debug!("Success!");
+        //               for mesh in m.meshes {
+        //                   debug!("Making mesh {}.{} available", model.cfg.name, mesh.name);
+        //                   db.geometry
+        //                       .insert(format!("{}.{}", model.cfg.name, mesh.name), mesh);
+        //               }
+        //           } else {
+        //               debug!("Failed!");
+        //           }
+        //       }
 
- //       // Images MUST be parsed before materials, as this loads images if they are used.
- //       for (name, mut m) in materials {
- //           m.load(scene, unsafe { &mut *ptr });
- //           if let Some(mat) = m.loaded {
- //               db.materials.insert(name, mat);
- //           }
- //       }
+        //       // Images MUST be parsed before materials, as this loads images if they are used.
+        //       for (name, mut m) in materials {
+        //           m.load(scene, unsafe { &mut *ptr });
+        //           if let Some(mat) = m.loaded {
+        //               db.materials.insert(name, mat);
+        //           }
+        //       }
 
         Ok(db)
     }
@@ -230,31 +227,31 @@ impl Database {
         Ok(())
     }
 
- //   fn insert_material(&mut self, name: &str, mat: Handle<koji::Material>) {
- //       if self.materials.get(name).is_none() {
- //           self.materials.insert(name.to_string(), mat);
- //       }
- //   }
+    //   fn insert_material(&mut self, name: &str, mat: Handle<koji::Material>) {
+    //       if self.materials.get(name).is_none() {
+    //           self.materials.insert(name.to_string(), mat);
+    //       }
+    //   }
 
- //   pub(crate) fn register_texture_from_bytes(&mut self, name: &str, data: &[u8]) {
- //       debug!(
- //           "Registering embedded GLTF model texture from bytes {}..",
- //           name
- //       );
- //       let image = unsafe {
- //           ImageResource::load_from_uri(name, data, &mut *self.ctx, &mut *self.scene)
- //       };
- //       self.images.insert(
- //           name.to_string(),
- //           ImageResource {
- //               cfg: json::ImageEntry {
- //                   name: name.to_string(),
- //                   path: Default::default(),
- //               },
- //               loaded: Some(image),
- //           },
- //       );
- //   }
+    //   pub(crate) fn register_texture_from_bytes(&mut self, name: &str, data: &[u8]) {
+    //       debug!(
+    //           "Registering embedded GLTF model texture from bytes {}..",
+    //           name
+    //       );
+    //       let image = unsafe {
+    //           ImageResource::load_from_uri(name, data, &mut *self.ctx, &mut *self.scene)
+    //       };
+    //       self.images.insert(
+    //           name.to_string(),
+    //           ImageResource {
+    //               cfg: json::ImageEntry {
+    //                   name: name.to_string(),
+    //                   path: Default::default(),
+    //               },
+    //               loaded: Some(image),
+    //           },
+    //       );
+    //   }
 
     pub fn fetch_texture(&mut self, name: &str) -> Result<Handle<koji::Texture>> {
         match self.textures.get_mut(name) {
@@ -289,43 +286,43 @@ impl Database {
             })),
         }
     }
-//        if let Some(thing) = self.images.get_mut(name) {
-//            if thing.loaded.is_none() {
-//                unsafe { thing.load_rgba8(&self.base_path, &mut *self.ctx, &mut *self.scene) };
-//            }
-//
-//            if thing.loaded.is_none() {
-//                return Err(Error::LoadingError(LoadingError {
-//                    entry: thing.cfg.name.clone(),
-//                    path: thing.cfg.path.clone(),
-//                }));
-//            } else {
-//                return Ok(thing.loaded.as_ref().unwrap().clone());
-//            }
-//        }
-//
-//        return Err(Error::LookupError(LookupError {
-//            entry: name.to_string(),
-//        }));
-//    }
+    //        if let Some(thing) = self.images.get_mut(name) {
+    //            if thing.loaded.is_none() {
+    //                unsafe { thing.load_rgba8(&self.base_path, &mut *self.ctx, &mut *self.scene) };
+    //            }
+    //
+    //            if thing.loaded.is_none() {
+    //                return Err(Error::LoadingError(LoadingError {
+    //                    entry: thing.cfg.name.clone(),
+    //                    path: thing.cfg.path.clone(),
+    //                }));
+    //            } else {
+    //                return Ok(thing.loaded.as_ref().unwrap().clone());
+    //            }
+    //        }
+    //
+    //        return Err(Error::LookupError(LookupError {
+    //            entry: name.to_string(),
+    //        }));
+    //    }
 
-//    pub fn fetch_material(&mut self, name: &str) -> Result<Handle<miso::Material>, Error> {
-//        todo!()
-//        if let Some(thing) = self.materials.get(name) {
-//            return Ok(*thing);
-//        } else {
-//            debug!("Unable to fetch material {}. Returning default...", name);
-//            return Ok(self.defaults.material);
-//        }
+    //    pub fn fetch_material(&mut self, name: &str) -> Result<Handle<miso::Material>, Error> {
+    //        todo!()
+    //        if let Some(thing) = self.materials.get(name) {
+    //            return Ok(*thing);
+    //        } else {
+    //            debug!("Unable to fetch material {}. Returning default...", name);
+    //            return Ok(self.defaults.material);
+    //        }
 
-//    pub fn fetch_mesh(&mut self, name: &str) -> Result<MeshResource, Error> {
-//        if let Some(thing) = self.geometry.get_mut(name) {
-//            return Ok(thing.clone());
-//        }
-//
-//        debug!("Unable to fetch model {}. Returning default sphere", name);
-//        return Ok(self.geometry.get("MESHI.CUBE").unwrap().clone());
-//    }
+    //    pub fn fetch_mesh(&mut self, name: &str) -> Result<MeshResource, Error> {
+    //        if let Some(thing) = self.geometry.get_mut(name) {
+    //            return Ok(thing.clone());
+    //        }
+    //
+    //        debug!("Unable to fetch model {}. Returning default sphere", name);
+    //        return Ok(self.geometry.get("MESHI.CUBE").unwrap().clone());
+    //    }
 }
 
 #[cfg(test)]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,8 @@ use database::{Database, Error as DatabaseError};
 use glam::{Mat4, Vec4};
 use tracing::info;
 
-use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo};
+use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo, MeshTarget};
+use crate::render::database::geometry_primitives::{self, CubePrimitiveInfo, SpherePrimitiveInfo};
 pub mod config;
 pub mod database;
 pub mod event;
@@ -206,6 +207,25 @@ impl RenderEngine {
         self.mesh_objects.insert(object).unwrap()
     }
 
+    pub fn create_cube_ex(&mut self, info: &CubePrimitiveInfo) -> Handle<MeshObject> {
+        let ctx = self.ctx.as_mut().expect("render context not initialized");
+        let mesh = geometry_primitives::make_cube(info, ctx);
+        let material = self
+            .database
+            .fetch_material("DEFAULT")
+            .expect("failed to fetch default material");
+        let target = MeshTarget {
+            mesh: mesh.clone(),
+            material,
+        };
+        let object = MeshObject {
+            targets: vec![target],
+            mesh,
+            transform: Mat4::IDENTITY,
+        };
+        self.mesh_objects.insert(object).unwrap()
+    }
+
     pub fn create_sphere(&mut self) -> Handle<MeshObject> {
         let info = MeshObjectInfo {
             mesh: "MESHI_SPHERE",
@@ -215,6 +235,25 @@ impl RenderEngine {
         let object = info
             .make_object(&mut self.database)
             .expect("failed to create mesh object");
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Handle<MeshObject> {
+        let ctx = self.ctx.as_mut().expect("render context not initialized");
+        let mesh = geometry_primitives::make_sphere(info, ctx);
+        let material = self
+            .database
+            .fetch_material("DEFAULT")
+            .expect("failed to fetch default material");
+        let target = MeshTarget {
+            mesh: mesh.clone(),
+            material,
+        };
+        let object = MeshObject {
+            targets: vec![target],
+            mesh,
+            transform: Mat4::IDENTITY,
+        };
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -239,10 +278,7 @@ impl RenderEngine {
             Some(obj) => {
                 obj.transform = *transform;
                 for target in &obj.targets {
-                    info!(
-                        "Submitting transform for mesh '{}'", 
-                        target.mesh.name
-                    );
+                    info!("Submitting transform for mesh '{}'", target.mesh.name);
                 }
             }
             None => {

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,3 +1,4 @@
+use meshi::render::database::geometry_primitives::{CubePrimitiveInfo, SpherePrimitiveInfo};
 use meshi::*;
 use std::ffi::CString;
 
@@ -11,7 +12,14 @@ fn main() {
     };
     let engine = unsafe { meshi_make_engine(&info) };
     assert!(!engine.is_null());
-    unsafe {
-        meshi_update(engine);
-    }
+    let render = unsafe { meshi_get_graphics_system(engine) };
+    let cube_info = CubePrimitiveInfo { size: 1.0 };
+    unsafe { meshi_gfx_create_cube_ex(render, &cube_info) };
+    let sphere_info = SpherePrimitiveInfo {
+        radius: 1.0,
+        segments: 8,
+        rings: 8,
+    };
+    unsafe { meshi_gfx_create_sphere_ex(render, &sphere_info) };
+    unsafe { meshi_update(engine) };
 }

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -1,5 +1,6 @@
 use glam::{Mat4, Quat, Vec3};
 use meshi::physics::{ActorStatus, RigidBodyInfo};
+use meshi::render::database::geometry_primitives::CubePrimitiveInfo;
 use meshi::*;
 use std::ffi::CString;
 
@@ -15,11 +16,10 @@ fn main() {
 
     // Graphics mesh object
     let render = unsafe { meshi_get_graphics_system(engine) };
-    let cube = unsafe { meshi_gfx_create_cube(render) };
+    let cube_info = CubePrimitiveInfo { size: 0.5 };
+    let cube = unsafe { meshi_gfx_create_cube_ex(render, &cube_info) };
     let transform = Mat4::from_translation(Vec3::new(1.0, 2.0, 3.0));
-    unsafe {
-        meshi_gfx_set_renderable_transform(render, cube, &transform);
-    }
+    unsafe { meshi_gfx_set_renderable_transform(render, cube, &transform) };
 
     // Physics rigid body
     let physics = unsafe { meshi_get_physics_system(engine) };


### PR DESCRIPTION
## Summary
- expose geometry primitive builders and make their info structs FFI-safe
- allow RenderEngine and FFI to build cubes and spheres with runtime parameters
- demonstrate custom primitive creation in example and tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e8a7ba2c4832a82d131c0b7f18bac