### PR TITLE
Add resource release functions for graphics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,8 @@ harness = false
 name = "scene"
 path = "tests/scene.rs"
 harness = false
+
+[[test]]
+name = "gfx_release"
+path = "tests/gfx_release.rs"
+harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,14 @@ pub extern "C" fn meshi_gfx_create_triangle(render: *mut RenderEngine) -> Handle
     unsafe { &mut *render }.create_triangle()
 }
 
+#[no_mangle]
+pub extern "C" fn meshi_gfx_release_mesh_object(
+    render: *mut RenderEngine,
+    h: *const Handle<MeshObject>,
+) {
+    unsafe { &mut *render }.release_mesh_object(unsafe { *h });
+}
+
 /// Update the transformation matrix for a renderable object.
 ///
 /// # Safety
@@ -235,6 +243,14 @@ pub extern "C" fn meshi_gfx_create_directional_light(
     info: *const DirectionalLightInfo,
 ) -> Handle<DirectionalLight> {
     unsafe { &mut *render }.register_directional_light(unsafe { &*info })
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_release_directional_light(
+    render: *mut RenderEngine,
+    h: *const Handle<DirectionalLight>,
+) {
+    unsafe { &mut *render }.release_directional_light(unsafe { *h });
 }
 
 /// Update the transform for a directional light.

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -186,12 +186,20 @@ impl RenderEngine {
         }
     }
 
+    pub fn release_directional_light(&mut self, handle: Handle<DirectionalLight>) {
+        self.directional_lights.release(handle);
+    }
+
     pub fn register_mesh_object(&mut self, info: &FFIMeshObjectInfo) -> Handle<MeshObject> {
         let info: MeshObjectInfo = info.into();
         let object = info
             .make_object(&mut self.database)
             .expect("failed to create mesh object");
         self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn release_mesh_object(&mut self, handle: Handle<MeshObject>) {
+        self.mesh_objects.release(handle);
     }
 
     pub fn create_cube(&mut self) -> Handle<MeshObject> {
@@ -239,10 +247,7 @@ impl RenderEngine {
             Some(obj) => {
                 obj.transform = *transform;
                 for target in &obj.targets {
-                    info!(
-                        "Submitting transform for mesh '{}'", 
-                        target.mesh.name
-                    );
+                    info!("Submitting transform for mesh '{}'", target.mesh.name);
                 }
             }
             None => {

--- a/tests/gfx_release.rs
+++ b/tests/gfx_release.rs
@@ -1,0 +1,28 @@
+use meshi::render::DirectionalLightInfo;
+use meshi::*;
+use std::ffi::CString;
+
+fn main() {
+    let name = CString::new("test").unwrap();
+    let loc = CString::new(".").unwrap();
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 1,
+    };
+    let engine = unsafe { meshi_make_engine(&info) };
+    let render = unsafe { meshi_get_graphics_system(engine) };
+
+    // Mesh object release
+    let cube1 = unsafe { meshi_gfx_create_cube(render) };
+    unsafe { meshi_gfx_release_mesh_object(render, &cube1) };
+    let cube2 = unsafe { meshi_gfx_create_cube(render) };
+    assert_eq!(cube1.slot, cube2.slot);
+
+    // Directional light release
+    let light_info = DirectionalLightInfo::default();
+    let light1 = unsafe { meshi_gfx_create_directional_light(render, &light_info) };
+    unsafe { meshi_gfx_release_directional_light(render, &light1) };
+    let light2 = unsafe { meshi_gfx_create_directional_light(render, &light_info) };
+    assert_eq!(light1.slot, light2.slot);
+}


### PR DESCRIPTION
## Summary
- allow renderer to release mesh objects and directional lights
- expose FFI helpers for releasing renderer resources
- test mesh and light release handles reuse

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e8a950ab0832a8f677b28ac455a05