### PR TITLE
Add explicit pointer checks and error codes

### DIFF
--- a/examples/ffi_physics.rs
+++ b/examples/ffi_physics.rs
@@ -19,11 +19,11 @@ fn main() {
         rotation: Quat::IDENTITY,
     };
     unsafe {
-        meshi_physx_set_rigid_body_transform(physics, &rb, &status);
+        let _ = meshi_physx_set_rigid_body_transform(physics, &rb, &status);
     }
     let mut out = ActorStatus::default();
     unsafe {
-        meshi_physx_get_rigid_body_status(physics, &rb, &mut out);
+        let _ = meshi_physx_get_rigid_body_status(physics, &rb, &mut out);
     }
     println!(
         "Rigid body position: {} {} {}",

--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -54,9 +54,9 @@ void meshi_physx_release_material(struct PhysicsSimulation* physics, const struc
 struct Handle meshi_physx_create_rigid_body(struct PhysicsSimulation* physics, const struct RigidBodyInfo* info);
 void meshi_physx_release_rigid_body(struct PhysicsSimulation* physics, const struct Handle* h);
 void meshi_physx_apply_force_to_rigid_body(struct PhysicsSimulation* physics, const struct Handle* h, const struct ForceApplyInfo* info);
-void meshi_physx_set_rigid_body_transform(struct PhysicsSimulation* physics, const struct Handle* h, const struct ActorStatus* info);
-void meshi_physx_get_rigid_body_status(struct PhysicsSimulation* physics, const struct Handle* h, struct ActorStatus* out_status);
-void meshi_physx_set_collision_shape(struct PhysicsSimulation* physics, const struct Handle* h, const struct CollisionShape* shape);
+int32_t meshi_physx_set_rigid_body_transform(struct PhysicsSimulation* physics, const struct Handle* h, const struct ActorStatus* info);
+int32_t meshi_physx_get_rigid_body_status(struct PhysicsSimulation* physics, const struct Handle* h, struct ActorStatus* out_status);
+int32_t meshi_physx_set_collision_shape(struct PhysicsSimulation* physics, const struct Handle* h, const struct CollisionShape* shape);
 size_t meshi_physx_get_contacts(struct PhysicsSimulation* physics, struct ContactInfo* out_contacts, size_t max);
 
 #ifdef __cplusplus

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -278,29 +278,51 @@ impl PhysicsSimulation {
             .push(info.amt);
     }
 
-    pub fn set_rigid_body_transform(&mut self, h: Handle<RigidBody>, info: &ActorStatus) {
-        assert!(h.valid());
+    pub fn set_rigid_body_transform(
+        &mut self,
+        h: Handle<RigidBody>,
+        info: &ActorStatus,
+    ) -> bool {
+        if !h.valid() {
+            return false;
+        }
         if let Some(rb) = self.rigid_bodies.get_mut_ref(h) {
             rb.position = info.position;
             rb.rotation = info.rotation;
+            true
+        } else {
+            false
         }
     }
 
-    pub fn set_rigid_body_collision_shape(&mut self, h: Handle<RigidBody>, shape: &CollisionShape) {
-        assert!(h.valid());
+    pub fn set_rigid_body_collision_shape(
+        &mut self,
+        h: Handle<RigidBody>,
+        shape: &CollisionShape,
+    ) -> bool {
+        if !h.valid() {
+            return false;
+        }
         if let Some(rb) = self.rigid_bodies.get_mut_ref(h) {
             rb.shape = *shape;
+            true
+        } else {
+            false
         }
     }
 
-    pub fn get_rigid_body_status(&self, h: Handle<RigidBody>) -> ActorStatus {
-        assert!(h.valid());
-        self.rigid_bodies.get_ref(h).unwrap().into()
+    pub fn get_rigid_body_status(&self, h: Handle<RigidBody>) -> Option<ActorStatus> {
+        if !h.valid() {
+            return None;
+        }
+        self.rigid_bodies.get_ref(h).map(|rb| rb.into())
     }
 
-    pub fn get_rigid_body_velocity(&self, h: Handle<RigidBody>) -> Vec3 {
-        assert!(h.valid());
-        self.rigid_bodies.get_ref(h).unwrap().velocity
+    pub fn get_rigid_body_velocity(&self, h: Handle<RigidBody>) -> Option<Vec3> {
+        if !h.valid() {
+            return None;
+        }
+        self.rigid_bodies.get_ref(h).map(|rb| rb.velocity)
     }
 
     pub fn get_contacts(&self) -> &[ContactInfo] {

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -29,11 +29,11 @@ fn main() {
         rotation: Quat::IDENTITY,
     };
     unsafe {
-        meshi_physx_set_rigid_body_transform(physics, &rb, &new_status);
+        assert_eq!(meshi_physx_set_rigid_body_transform(physics, &rb, &new_status), 1);
     }
     let mut out = ActorStatus::default();
     unsafe {
-        meshi_physx_get_rigid_body_status(physics, &rb, &mut out);
+        assert_eq!(meshi_physx_get_rigid_body_status(physics, &rb, &mut out), 1);
     }
     assert_eq!(out.position, new_status.position);
     assert_eq!(out.rotation, new_status.rotation);

--- a/tests/physics_update.rs
+++ b/tests/physics_update.rs
@@ -11,8 +11,12 @@ fn physics_update_applies_gravity_and_damping() {
     let dt = 1.0f32;
     sim.update(dt);
 
-    let status = sim.get_rigid_body_status(rb);
-    let velocity = sim.get_rigid_body_velocity(rb);
+    let status = sim
+        .get_rigid_body_status(rb)
+        .expect("rigid body should be valid");
+    let velocity = sim
+        .get_rigid_body_velocity(rb)
+        .expect("rigid body should be valid");
 
     let g = -9.8f32;
     let friction = MaterialInfo::default().dynamic_friction_m;


### PR DESCRIPTION
## Summary
- validate C string pointers when constructing `MeshiEngine`
- replace physics `assert!` calls with `bool`/`Option` results
- propagate error codes through FFI and update header/tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688eded329cc832a80bcf937ba2c3a5b