### PR TITLE
Expose elapsed Duration for Timer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,12 @@ impl MeshiEngine {
         if info.application_name.is_null() || info.application_location.is_null() {
             return None;
         }
-        let appname = unsafe { CStr::from_ptr(info.application_name) }.to_str().ok()?;
-        let mut appdir = unsafe { CStr::from_ptr(info.application_location) }.to_str().ok()?;
+        let appname = unsafe { CStr::from_ptr(info.application_name) }
+            .to_str()
+            .ok()?;
+        let mut appdir = unsafe { CStr::from_ptr(info.application_location) }
+            .to_str()
+            .ok()?;
 
         if appdir.is_empty() {
             appdir = ".";
@@ -68,12 +72,13 @@ impl MeshiEngine {
 
     fn update(&mut self) -> f32 {
         self.frame_timer.stop();
-        let dt = self.frame_timer.elapsed_seconds_f32();
+        let dt = self.frame_timer.elapsed_duration();
         self.frame_timer.start();
-        self.render.update(dt);
-        self.physics.update(dt);
+        let dt_secs = dt.as_secs_f32();
+        self.render.update(dt_secs);
+        self.physics.update(dt_secs);
 
-        dt
+        dt_secs
     }
 }
 
@@ -94,8 +99,7 @@ pub extern "C" fn meshi_make_engine(info: *const MeshiEngineInfo) -> *mut MeshiE
         // completes the builder.
         .finish();
 
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("setting default subscriber failed");
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     if info.is_null() {
         return std::ptr::null_mut();
@@ -449,7 +453,7 @@ pub extern "C" fn meshi_physx_set_rigid_body_transform(
     physics: *mut PhysicsSimulation,
     h: *const Handle<physics::RigidBody>,
     info: *const physics::ActorStatus,
-    ) -> i32 {
+) -> i32 {
     if physics.is_null() || h.is_null() || info.is_null() {
         return 0;
     }
@@ -471,7 +475,7 @@ pub extern "C" fn meshi_physx_get_rigid_body_status(
     physics: *mut PhysicsSimulation,
     h: *const Handle<physics::RigidBody>,
     out_status: *mut physics::ActorStatus,
-    ) -> i32 {
+) -> i32 {
     if physics.is_null() || h.is_null() || out_status.is_null() {
         return 0;
     }
@@ -492,13 +496,11 @@ pub extern "C" fn meshi_physx_set_collision_shape(
     physics: *mut PhysicsSimulation,
     h: *const Handle<physics::RigidBody>,
     shape: *const CollisionShape,
-    ) -> i32 {
+) -> i32 {
     if physics.is_null() || h.is_null() || shape.is_null() {
         return 0;
     }
-    if unsafe { &mut *physics }
-        .set_rigid_body_collision_shape(unsafe { *h }, unsafe { &*shape })
-    {
+    if unsafe { &mut *physics }.set_rigid_body_collision_shape(unsafe { *h }, unsafe { &*shape }) {
         1
     } else {
         0

--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -31,8 +31,8 @@ impl Timer {
 
     // Stop the timer
     pub fn stop(&mut self) {
-        if let Some(start_time) = self.start_time {
-            self.elapsed = start_time.elapsed();
+        if self.start_time.is_some() {
+            self.elapsed = self.elapsed_duration();
             self.start_time = None;
             self.is_paused = false;
         }
@@ -40,8 +40,8 @@ impl Timer {
 
     // Pause the timer
     pub fn pause(&mut self) {
-        if let Some(start_time) = self.start_time {
-            self.elapsed = start_time.elapsed();
+        if self.start_time.is_some() {
+            self.elapsed = self.elapsed_duration();
             self.is_paused = true;
             self.start_time = None;
         }
@@ -54,34 +54,36 @@ impl Timer {
         self.is_paused = false;
     }
 
-    // Get the current elapsed time in milliseconds
-    pub fn elapsed_ms(&self) -> u128 {
+    // Get the current elapsed duration
+    pub fn elapsed_duration(&self) -> Duration {
         if let Some(start_time) = self.start_time {
             if self.is_paused {
-                self.elapsed.as_millis()
+                self.elapsed
             } else {
-                start_time.elapsed().as_millis()
+                start_time.elapsed()
             }
         } else {
-            self.elapsed.as_millis()
+            self.elapsed
         }
     }
 
     // Get the current elapsed time in milliseconds
+    pub fn elapsed_ms(&self) -> u128 {
+        self.elapsed_duration().as_millis()
+    }
+
+    // Get the current elapsed time in microseconds
     pub fn elapsed_micro(&self) -> u128 {
-        if let Some(start_time) = self.start_time {
-            if self.is_paused {
-                self.elapsed.as_micros()
-            } else {
-                start_time.elapsed().as_micros()
-            }
-        } else {
-            self.elapsed.as_micros()
-        }
+        self.elapsed_duration().as_micros()
     }
 
     // Get the current elapsed time in seconds as f32
     pub fn elapsed_seconds_f32(&self) -> f32 {
-        self.elapsed_micro() as f32 / 1_000_000.0
+        self.elapsed_duration().as_secs_f32()
+    }
+
+    // Get the current elapsed time in seconds as f64
+    pub fn elapsed_seconds_f64(&self) -> f64 {
+        self.elapsed_duration().as_secs_f64()
     }
 }


### PR DESCRIPTION
## Summary
- centralize timing logic in `elapsed_duration`
- support `elapsed_seconds_f64` for high precision
- use duration-based timer in engine update

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688ef51b2a3c832abaa1d1aaa6537c86