### PR TITLE
Add render backend selection

### DIFF
--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -1,0 +1,7 @@
+pub struct CanvasBackend;
+
+impl CanvasBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -1,0 +1,7 @@
+pub struct GraphBackend;
+
+impl GraphBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -1,5 +1,5 @@
 use image::{Rgba, RgbaImage};
-use meshi::render::{RenderEngine, RenderEngineInfo, SceneInfo};
+use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
 use std::fs;
 
 fn main() {
@@ -49,6 +49,7 @@ fn main() {
         application_path: dir.to_str().unwrap().into(),
         scene_info: None,
         headless: true,
+        backend: RenderBackend::Canvas,
     })
     .expect("failed to initialize renderer");
 


### PR DESCRIPTION
## Summary
- add `RenderBackend` enum and store backend in `RenderEngine`
- create placeholder `CanvasBackend` and `GraphBackend`
- allow callers to choose backend via `RenderEngineInfo`

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688ef84f29a8832ab64ccffcf43966b5