### PR TITLE
Add FFI header synchronization test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Run the test suite to verify functionality:
 cargo test
 ```
 
+Whenever altering FFI signatures or structs, update `include/meshi/meshi.h` and `meshi_types.h`, then run `cargo test` to verify synchronization.
+
 ## Examples
 
 Sample code demonstrating the FFI interface lives in the `examples/` directory. Run an example with:

--- a/tests/ffi_header_sync.rs
+++ b/tests/ffi_header_sync.rs
@@ -1,0 +1,26 @@
+use std::fs;
+
+#[test]
+fn ffi_header_sync() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let lib_rs =
+        fs::read_to_string(format!("{}/src/lib.rs", root)).expect("failed to read src/lib.rs");
+    let header = fs::read_to_string(format!("{}/include/meshi/meshi.h", root))
+        .expect("failed to read include/meshi/meshi.h");
+
+    let mut missing = Vec::new();
+    for line in lib_rs.lines() {
+        if let Some(start) = line.find("pub extern \"C\" fn") {
+            let after = &line[start + "pub extern \"C\" fn".len()..];
+            let name = after
+                .split(|c: char| c == '(' || c.is_whitespace())
+                .next()
+                .unwrap();
+            if !header.contains(name) {
+                missing.push(name.to_string());
+            }
+        }
+    }
+
+    assert!(missing.is_empty(), "Missing in meshi.h: {:?}", missing);
+}


### PR DESCRIPTION
## Summary
- add test ensuring all `pub extern "C"` functions in `src/lib.rs` are declared in `include/meshi/meshi.h`
- document requirement to update FFI headers when altering signatures or structs

## Testing
- `cargo test`
- `cargo test --test ffi_header_sync`


------
https://chatgpt.com/codex/tasks/task_e_688f9c04c220832abd386188308a21fb