### PR TITLE
Add canvas renderer backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,19 +401,6 @@ dependencies = [
 [[package]]
 name = "dashi"
 version = "0.1.0"
-source = "git+https://github.com/JordanHendl/dashi?branch=main#b3da472c4cd2aef75f686ab14ace86e3c4f50f1c"
-dependencies = [
- "ash",
- "ash-window",
- "raw-window-handle",
- "serde",
- "vk-mem",
- "winit",
-]
-
-[[package]]
-name = "dashi"
-version = "0.1.0"
 source = "git+https://github.com/JordanHendl/dashi#b3da472c4cd2aef75f686ab14ace86e3c4f50f1c"
 dependencies = [
  "ash",
@@ -768,7 +755,7 @@ version = "0.1.0"
 source = "git+https://github.com/JordanHendl/koji?branch=main#9caeab7fda99266ce7897710bfa7e7766fd5bafd"
 dependencies = [
  "bytemuck",
- "dashi 0.1.0 (git+https://github.com/JordanHendl/dashi)",
+ "dashi",
  "glam",
  "gltf",
  "image 0.24.9",
@@ -891,7 +878,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "bytemuck",
- "dashi 0.1.0 (git+https://github.com/JordanHendl/dashi?branch=main)",
+ "dashi",
  "fontdue",
  "glam",
  "gltf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ image = "0.24"
 fontdue = "0.9.2"
 #dashi = {path = "/wksp/git/dashi", features = ["dashi-serde"]}
 #miso = {path = "/wksp/git/miso"}
-dashi = {version = "0.1.0", git = "https://github.com/JordanHendl/dashi", features = ["dashi-serde"], branch = "main"}
+dashi = {version = "0.1.0", git = "https://github.com/JordanHendl/dashi", features = ["dashi-serde"]}
 koji = {version = "0.1.0", git = "https://github.com/JordanHendl/koji", branch = "main"}
 gltf = "1.4.1"  # For reading glTF files
 unzip3 = "1.0.0"

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -1,7 +1,76 @@
-pub struct CanvasBackend;
+use dashi::{utils::Pool, Attachment, DrawIndexed, Format, RenderPassBegin, SubmitInfo};
+use koji::{Canvas, CanvasBuilder};
 
-impl CanvasBackend {
+use crate::object::MeshObject;
+
+pub struct CanvasRenderer {
+    canvas: Option<Canvas>,
+}
+
+impl CanvasRenderer {
     pub fn new() -> Self {
-        Self
+        Self { canvas: None }
+    }
+
+    pub fn render(
+        &mut self,
+        ctx: &mut dashi::Context,
+        display: &mut dashi::Display,
+        mesh_objects: &Pool<MeshObject>,
+    ) {
+        let canvas = self.canvas.get_or_insert_with(|| {
+            CanvasBuilder::new()
+                .color_attachment("color", Format::RGBA8)
+                .build(ctx)
+                .expect("failed to build canvas")
+        });
+
+        let (img, acquire_sem, _idx, _sub_opt) = ctx
+            .acquire_new_image(display)
+            .expect("failed to acquire image");
+        canvas.target_mut().colors[0].attachment.img = img;
+
+        let target = canvas.target();
+        let mut attachments: Vec<Attachment> = target.colors.iter().map(|c| c.attachment).collect();
+        if let Some(depth) = &target.depth {
+            attachments.push(depth.attachment);
+        }
+
+        let mut cmd = ctx
+            .begin_command_list(&Default::default())
+            .expect("begin command list");
+
+        cmd.begin_render_pass(&RenderPassBegin {
+            render_pass: canvas.render_pass(),
+            viewport: Default::default(),
+            attachments: &attachments,
+        })
+        .expect("begin render pass");
+
+        mesh_objects.for_each_occupied(|obj| {
+            cmd.draw_indexed(DrawIndexed {
+                vertices: obj.mesh.vertices,
+                indices: obj.mesh.indices,
+                index_count: obj.mesh.num_indices as u32,
+                ..Default::default()
+            });
+        });
+
+        // ensure render pass closed
+        let _ = cmd.end_drawing();
+
+        let fence = ctx
+            .submit(
+                &mut cmd,
+                &SubmitInfo {
+                    wait_sems: &[acquire_sem],
+                    signal_sems: &[],
+                },
+            )
+            .expect("submit");
+
+        let _ = ctx.wait(fence);
+        let _ = ctx.present_display(display, &[]);
+        ctx.destroy_cmd_list(cmd);
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -113,7 +113,7 @@ pub struct RenderEngine {
 }
 
 enum Backend {
-    Canvas(canvas::CanvasBackend),
+    Canvas(canvas::CanvasRenderer),
     Graph(graph::GraphBackend),
 }
 
@@ -130,7 +130,7 @@ impl RenderEngine {
         let backend = match info.backend {
             RenderBackend::Canvas => {
                 info!("Using canvas backend");
-                Backend::Canvas(canvas::CanvasBackend::new())
+                Backend::Canvas(canvas::CanvasRenderer::new())
             }
             RenderBackend::Graph => {
                 info!("Using graph backend");
@@ -368,6 +368,13 @@ impl RenderEngine {
                 let mut synthetic: event::Event = unsafe { std::mem::zeroed() };
                 let c = cb.event_cb;
                 c(&mut synthetic, cb.user_data);
+            }
+        }
+
+        if let (Some(ctx), Some(display)) = (self.ctx.as_mut(), self.display.as_mut()) {
+            match &mut self.backend {
+                Backend::Canvas(r) => r.render(ctx, display, &self.mesh_objects),
+                Backend::Graph(_) => {}
             }
         }
     }


### PR DESCRIPTION
## Summary
- introduce `CanvasRenderer` to draw mesh objects with a Koji canvas and present the frame
- hook the canvas renderer into backend selection and per-frame updates

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688faf1d6938832a8985942382cfc01a