### PR TITLE
Add timer utility tests

### DIFF
--- a/src/utils/timer.rs
+++ b/src/utils/timer.rs
@@ -5,7 +5,6 @@ pub struct Timer {
     is_paused: bool,
 }
 
-#[allow(dead_code)]
 impl Timer {
     // Create a new timer instance
     pub fn new() -> Timer {
@@ -18,14 +17,14 @@ impl Timer {
 
     // Start the timer
     pub fn start(&mut self) {
-        if self.start_time.is_none() {
-            self.start_time = Some(Instant::now());
-        } else if self.is_paused {
+        if self.is_paused {
             // Resume from where it was paused
             self.start_time = Some(Instant::now() - self.elapsed);
             self.is_paused = false;
         } else {
+            // Start or restart the timer
             self.start_time = Some(Instant::now());
+            self.elapsed = Duration::new(0, 0);
         }
     }
 

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -1,0 +1,64 @@
+use std::{thread, time::Duration};
+
+mod timer {
+    include!("../src/utils/timer.rs");
+}
+use timer::Timer;
+
+#[test]
+fn start_records_elapsed_time() {
+    let mut timer = Timer::new();
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    assert!(timer.elapsed_ms() >= 10);
+}
+
+#[test]
+fn pause_freezes_elapsed_time() {
+    let mut timer = Timer::new();
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    timer.pause();
+    let paused = timer.elapsed_ms();
+    thread::sleep(Duration::from_millis(10));
+    assert_eq!(paused, timer.elapsed_ms());
+}
+
+#[test]
+fn resume_continues_after_pause() {
+    let mut timer = Timer::new();
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    timer.pause();
+    let paused = timer.elapsed_ms();
+    thread::sleep(Duration::from_millis(10));
+    assert_eq!(paused, timer.elapsed_ms());
+
+    timer.start(); // resume
+    thread::sleep(Duration::from_millis(10));
+    assert!(timer.elapsed_ms() > paused);
+}
+
+#[test]
+fn stop_stops_elapsed_time() {
+    let mut timer = Timer::new();
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    timer.stop();
+    let stopped = timer.elapsed_ms();
+    thread::sleep(Duration::from_millis(10));
+    assert_eq!(stopped, timer.elapsed_ms());
+}
+
+#[test]
+fn reset_clears_elapsed_time() {
+    let mut timer = Timer::new();
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    timer.reset();
+    assert_eq!(timer.elapsed_ms(), 0);
+
+    timer.start();
+    thread::sleep(Duration::from_millis(10));
+    assert!(timer.elapsed_ms() >= 10);
+}


### PR DESCRIPTION
## Summary
- fix timer `start` logic to handle resume and restart cleanly
- test timer start, pause, resume, stop, and reset behavior

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_688faf503404832a9e6d4bb22a98fc60