### PR TITLE
Add box collision shapes and detection

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -16,6 +16,7 @@ struct MeshObject;
 struct DirectionalLightInfo;
 struct DirectionalLight;
 struct Mat4;
+struct Vec3;
 struct PhysicsSimulation;
 struct MaterialInfo;
 struct RigidBodyInfo;
@@ -58,6 +59,8 @@ int32_t meshi_physx_set_rigid_body_transform(struct PhysicsSimulation* physics, 
 int32_t meshi_physx_get_rigid_body_status(struct PhysicsSimulation* physics, const struct Handle* h, struct ActorStatus* out_status);
 int32_t meshi_physx_set_collision_shape(struct PhysicsSimulation* physics, const struct Handle* h, const struct CollisionShape* shape);
 size_t meshi_physx_get_contacts(struct PhysicsSimulation* physics, struct ContactInfo* out_contacts, size_t max);
+struct CollisionShape meshi_physx_collision_shape_sphere(float radius);
+struct CollisionShape meshi_physx_collision_shape_box(struct Vec3 dimensions);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/meshi/meshi_types.h
+++ b/include/meshi/meshi_types.h
@@ -227,11 +227,13 @@ struct MeshiForceApplyInfo {
 
 enum class MeshiCollisionShapeType : std::uint32_t {
     Sphere = 0,
+    Box = 1,
 };
 
-struct MeshiCollisionShape {
-    MeshiCollisionShapeType shape_type;
+struct alignas(16) MeshiCollisionShape {
+    MeshiVec3 dimensions;
     float radius;
+    MeshiCollisionShapeType shape_type;
 };
 
 struct MeshiRigidBodyInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@ pub mod physics;
 pub mod render;
 mod utils;
 use dashi::utils::Handle;
-use glam::Mat4;
+use glam::{Mat4, Vec3};
 use object::{FFIMeshObjectInfo, MeshObject};
-use physics::{CollisionShape, ContactInfo, ForceApplyInfo, PhysicsSimulation};
+use physics::{CollisionShape, CollisionShapeType, ContactInfo, ForceApplyInfo, PhysicsSimulation};
 use render::{
     DirectionalLight, DirectionalLightInfo, RenderBackend, RenderEngine, RenderEngineInfo,
 };
@@ -531,6 +531,24 @@ pub extern "C" fn meshi_physx_get_contacts(
         std::ptr::copy_nonoverlapping(contacts.as_ptr(), out_contacts, count);
     }
     count
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_physx_collision_shape_sphere(radius: f32) -> CollisionShape {
+    CollisionShape {
+        dimensions: Vec3::ZERO,
+        radius,
+        shape_type: CollisionShapeType::Sphere,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_physx_collision_shape_box(dimensions: Vec3) -> CollisionShape {
+    CollisionShape {
+        dimensions,
+        radius: 0.0,
+        shape_type: CollisionShapeType::Box,
+    }
 }
 
 #[cfg(test)]

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -45,13 +45,17 @@ pub struct ForceApplyInfo {
 pub enum CollisionShapeType {
     #[default]
     Sphere = 0,
+    Box = 1,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CollisionShape {
-    pub shape_type: CollisionShapeType,
+    /// Full extents of the box shape. For spheres this value is ignored.
+    pub dimensions: Vec3,
+    /// Radius for sphere shapes. For boxes this value is ignored.
     pub radius: f32,
+    pub shape_type: CollisionShapeType,
 }
 
 impl Default for CollisionShape {
@@ -59,6 +63,7 @@ impl Default for CollisionShape {
         Self {
             shape_type: CollisionShapeType::Sphere,
             radius: 1.0,
+            dimensions: Vec3::ONE,
         }
     }
 }
@@ -128,6 +133,45 @@ pub struct ContactInfo {
     pub b: Handle<RigidBody>,
     pub normal: Vec3,
     pub penetration: f32,
+}
+
+fn collide_sphere_box(
+    sphere_pos: Vec3,
+    radius: f32,
+    box_pos: Vec3,
+    box_half: Vec3,
+) -> Option<(Vec3, f32)> {
+    let diff = sphere_pos - box_pos;
+    let closest = vec3(
+        diff.x.clamp(-box_half.x, box_half.x),
+        diff.y.clamp(-box_half.y, box_half.y),
+        diff.z.clamp(-box_half.z, box_half.z),
+    );
+    let delta = diff - closest;
+    let dist_sq = delta.length_squared();
+    if dist_sq < radius * radius {
+        let dist = dist_sq.sqrt();
+        if dist > 0.0 {
+            let normal = -(delta / dist);
+            Some((normal, radius - dist))
+        } else {
+            let over_x = box_half.x - diff.x.abs();
+            let over_y = box_half.y - diff.y.abs();
+            let over_z = box_half.z - diff.z.abs();
+            if over_x < over_y && over_x < over_z {
+                let normal = vec3(if diff.x > 0.0 { -1.0 } else { 1.0 }, 0.0, 0.0);
+                Some((normal, radius + over_x))
+            } else if over_y < over_z {
+                let normal = vec3(0.0, if diff.y > 0.0 { -1.0 } else { 1.0 }, 0.0);
+                Some((normal, radius + over_y))
+            } else {
+                let normal = vec3(0.0, 0.0, if diff.z > 0.0 { -1.0 } else { 1.0 });
+                Some((normal, radius + over_z))
+            }
+        }
+    } else {
+        None
+    }
 }
 
 impl From<&RigidBodyInfo> for RigidBody {
@@ -204,9 +248,17 @@ impl PhysicsSimulation {
         let mut max_radius = 0.0f32;
         for &h in &handles {
             let rb = self.rigid_bodies.get_ref(h).unwrap();
-            max_radius = max_radius.max(rb.shape.radius);
+            let r = match rb.shape.shape_type {
+                CollisionShapeType::Sphere => rb.shape.radius,
+                CollisionShapeType::Box => rb.shape.dimensions.max_element() * 0.5,
+            };
+            max_radius = max_radius.max(r);
         }
-        let cell_size = if max_radius > 0.0 { max_radius * 2.0 } else { 1.0 };
+        let cell_size = if max_radius > 0.0 {
+            max_radius * 2.0
+        } else {
+            1.0
+        };
 
         // Populate the grid
         let mut grid: HashMap<(i32, i32, i32), Vec<Handle<RigidBody>>> = HashMap::new();
@@ -222,20 +274,65 @@ impl PhysicsSimulation {
 
         // Helper closure to process a potential pair
         let mut process_pair = |ha: Handle<RigidBody>, hb: Handle<RigidBody>| {
-            let a_pos = self.rigid_bodies.get_ref(ha).unwrap().position;
-            let b_pos = self.rigid_bodies.get_ref(hb).unwrap().position;
-            let a_vel = self.rigid_bodies.get_ref(ha).unwrap().velocity;
-            let b_vel = self.rigid_bodies.get_ref(hb).unwrap().velocity;
-            let a_rad = self.rigid_bodies.get_ref(ha).unwrap().shape.radius;
-            let b_rad = self.rigid_bodies.get_ref(hb).unwrap().shape.radius;
+            let a_ref = self.rigid_bodies.get_ref(ha).unwrap();
+            let b_ref = self.rigid_bodies.get_ref(hb).unwrap();
+            let a_pos = a_ref.position;
+            let b_pos = b_ref.position;
+            let a_vel = a_ref.velocity;
+            let b_vel = b_ref.velocity;
+            let a_shape = a_ref.shape;
+            let b_shape = b_ref.shape;
 
-            let delta = b_pos - a_pos;
-            let dist = delta.length();
-            let penetration = a_rad + b_rad - dist;
-            if penetration > 0.0 {
-                let normal = if dist > 0.0 { delta / dist } else { Vec3::Z };
+            let mut result: Option<(Vec3, f32)> = None;
+
+            match (a_shape.shape_type, b_shape.shape_type) {
+                (CollisionShapeType::Sphere, CollisionShapeType::Sphere) => {
+                    let delta = b_pos - a_pos;
+                    let dist = delta.length();
+                    let penetration = a_shape.radius + b_shape.radius - dist;
+                    if penetration > 0.0 {
+                        let normal = if dist > 0.0 { delta / dist } else { Vec3::Z };
+                        result = Some((normal, penetration));
+                    }
+                }
+                (CollisionShapeType::Box, CollisionShapeType::Box) => {
+                    let a_half = a_shape.dimensions * 0.5;
+                    let b_half = b_shape.dimensions * 0.5;
+                    let delta = b_pos - a_pos;
+                    let overlap_x = a_half.x + b_half.x - delta.x.abs();
+                    let overlap_y = a_half.y + b_half.y - delta.y.abs();
+                    let overlap_z = a_half.z + b_half.z - delta.z.abs();
+                    if overlap_x > 0.0 && overlap_y > 0.0 && overlap_z > 0.0 {
+                        if overlap_x < overlap_y && overlap_x < overlap_z {
+                            let normal = vec3(delta.x.signum(), 0.0, 0.0);
+                            result = Some((normal, overlap_x));
+                        } else if overlap_y < overlap_z {
+                            let normal = vec3(0.0, delta.y.signum(), 0.0);
+                            result = Some((normal, overlap_y));
+                        } else {
+                            let normal = vec3(0.0, 0.0, delta.z.signum());
+                            result = Some((normal, overlap_z));
+                        }
+                    }
+                }
+                (CollisionShapeType::Sphere, CollisionShapeType::Box) => {
+                    if let Some((normal, penetration)) =
+                        collide_sphere_box(a_pos, a_shape.radius, b_pos, b_shape.dimensions * 0.5)
+                    {
+                        result = Some((normal, penetration));
+                    }
+                }
+                (CollisionShapeType::Box, CollisionShapeType::Sphere) => {
+                    if let Some((normal, penetration)) =
+                        collide_sphere_box(b_pos, b_shape.radius, a_pos, a_shape.dimensions * 0.5)
+                    {
+                        result = Some((-normal, penetration));
+                    }
+                }
+            }
+
+            if let Some((normal, penetration)) = result {
                 let correction = normal * (penetration / 2.0);
-
                 let rel_vel = b_vel - a_vel;
                 let vel_along_normal = rel_vel.dot(normal);
                 let mut a_vel_new = a_vel;
@@ -341,11 +438,7 @@ impl PhysicsSimulation {
             .push(info.amt);
     }
 
-    pub fn set_rigid_body_transform(
-        &mut self,
-        h: Handle<RigidBody>,
-        info: &ActorStatus,
-    ) -> bool {
+    pub fn set_rigid_body_transform(&mut self, h: Handle<RigidBody>, info: &ActorStatus) -> bool {
         if !h.valid() {
             return false;
         }

--- a/tests/physics_collision.rs
+++ b/tests/physics_collision.rs
@@ -1,5 +1,7 @@
 use glam::Vec3;
-use meshi::physics::{PhysicsSimulation, RigidBodyInfo, SimulationInfo};
+use meshi::physics::{
+    CollisionShape, CollisionShapeType, PhysicsSimulation, RigidBodyInfo, SimulationInfo,
+};
 
 #[test]
 fn spheres_generate_contact() {
@@ -46,4 +48,59 @@ fn many_spheres_generate_expected_contacts() {
             .iter()
             .any(|c| (c.a == a && c.b == b) || (c.a == b && c.b == a)));
     }
+}
+
+#[test]
+fn boxes_generate_contact() {
+    let mut sim = PhysicsSimulation::new(&SimulationInfo::default());
+    let box_shape = CollisionShape {
+        shape_type: CollisionShapeType::Box,
+        dimensions: Vec3::splat(1.0),
+        radius: 0.0,
+    };
+    let rb1 = sim.create_rigid_body(&RigidBodyInfo {
+        initial_position: Vec3::ZERO,
+        has_gravity: 0,
+        collision_shape: box_shape,
+        ..Default::default()
+    });
+    let rb2 = sim.create_rigid_body(&RigidBodyInfo {
+        initial_position: Vec3::new(0.9, 0.0, 0.0),
+        has_gravity: 0,
+        collision_shape: box_shape,
+        ..Default::default()
+    });
+
+    sim.update(0.0);
+    let contacts = sim.get_contacts();
+    assert!(contacts
+        .iter()
+        .any(|c| (c.a == rb1 && c.b == rb2) || (c.a == rb2 && c.b == rb1)));
+}
+
+#[test]
+fn box_and_sphere_generate_contact() {
+    let mut sim = PhysicsSimulation::new(&SimulationInfo::default());
+    let box_shape = CollisionShape {
+        shape_type: CollisionShapeType::Box,
+        dimensions: Vec3::splat(1.0),
+        radius: 0.0,
+    };
+    let box_rb = sim.create_rigid_body(&RigidBodyInfo {
+        initial_position: Vec3::ZERO,
+        has_gravity: 0,
+        collision_shape: box_shape,
+        ..Default::default()
+    });
+    let sphere_rb = sim.create_rigid_body(&RigidBodyInfo {
+        initial_position: Vec3::new(1.4, 0.0, 0.0),
+        has_gravity: 0,
+        ..Default::default()
+    });
+
+    sim.update(0.0);
+    let contacts = sim.get_contacts();
+    assert!(contacts
+        .iter()
+        .any(|c| { (c.a == box_rb && c.b == sphere_rb) || (c.a == sphere_rb && c.b == box_rb) }));
 }


### PR DESCRIPTION
## Summary
- Extend physics collision shapes with a new Box variant and dimension support
- Implement box-vs-box and box-vs-sphere collision detection and resolution
- Expose collision shape constructors for spheres and boxes in the FFI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688fb15a0e40832abc4b2b07d20a13cf