### PR TITLE
Expose gravity configuration

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -49,6 +49,7 @@ void meshi_gfx_capture_mouse(struct RenderEngine* render, int32_t value);
 
 // Physics
 struct PhysicsSimulation* meshi_get_physics_system(struct MeshiEngine* engine);
+void meshi_physx_set_gravity(struct PhysicsSimulation* physics, float gravity_mps);
 struct Handle meshi_physx_create_material(struct PhysicsSimulation* physics, const struct MaterialInfo* info);
 void meshi_physx_release_material(struct PhysicsSimulation* physics, const struct Handle* h);
 struct Handle meshi_physx_create_rigid_body(struct PhysicsSimulation* physics, const struct RigidBodyInfo* info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,19 @@ pub extern "C" fn meshi_get_physics_system(engine: *mut MeshiEngine) -> *mut Phy
     unsafe { (*engine).physics.as_mut() as *mut PhysicsSimulation }
 }
 
+/// Set the gravitational acceleration for the physics simulation.
+///
+/// # Safety
+/// `physics` must be a valid pointer. The gravity is expressed in meters per
+/// second squared.
+#[no_mangle]
+pub extern "C" fn meshi_physx_set_gravity(physics: *mut PhysicsSimulation, gravity_mps: f32) {
+    if physics.is_null() {
+        return;
+    }
+    unsafe { &mut *physics }.set_gravity(gravity_mps);
+}
+
 /// Create a new material in the physics system.
 ///
 /// # Safety


### PR DESCRIPTION
## Summary
- make `EnvironmentInfo::gravity_mps` public with a constructor and docs
- add `PhysicsSimulation::set_gravity` and expose FFI `meshi_physx_set_gravity`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688fb164cb24832a8abb31be0df18cdc