### PR TITLE
Implement VirtualKeyCode to KeyCode conversion

### DIFF
--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -416,111 +416,61 @@ use winit::event::{
 //    }
 //}
 
-fn map_virtual_keycode(key: VirtualKeyCode) -> KeyCode {
-    use VirtualKeyCode::*;
-    match key {
-        A => KeyCode::A,
-        B => KeyCode::B,
-        C => KeyCode::C,
-        D => KeyCode::D,
-        E => KeyCode::E,
-        F => KeyCode::F,
-        G => KeyCode::G,
-        H => KeyCode::H,
-        I => KeyCode::I,
-        J => KeyCode::J,
-        K => KeyCode::K,
-        L => KeyCode::L,
-        M => KeyCode::M,
-        N => KeyCode::N,
-        O => KeyCode::O,
-        P => KeyCode::P,
-        Q => KeyCode::Q,
-        R => KeyCode::R,
-        S => KeyCode::S,
-        T => KeyCode::T,
-        U => KeyCode::U,
-        V => KeyCode::V,
-        W => KeyCode::W,
-        X => KeyCode::X,
-        Y => KeyCode::Y,
-        Z => KeyCode::Z,
-        Key0 => KeyCode::Digit0,
-        Key1 => KeyCode::Digit1,
-        Key2 => KeyCode::Digit2,
-        Key3 => KeyCode::Digit3,
-        Key4 => KeyCode::Digit4,
-        Key5 => KeyCode::Digit5,
-        Key6 => KeyCode::Digit6,
-        Key7 => KeyCode::Digit7,
-        Key8 => KeyCode::Digit8,
-        Key9 => KeyCode::Digit9,
-        Escape => KeyCode::Escape,
-        Return => KeyCode::Enter,
-        Space => KeyCode::Space,
-        Tab => KeyCode::Tab,
-        Back => KeyCode::Backspace,
-        Insert => KeyCode::Insert,
-        Delete => KeyCode::Delete,
-        Home => KeyCode::Home,
-        End => KeyCode::End,
-        PageUp => KeyCode::PageUp,
-        PageDown => KeyCode::PageDown,
-        Left => KeyCode::ArrowLeft,
-        Right => KeyCode::ArrowRight,
-        Up => KeyCode::ArrowUp,
-        Down => KeyCode::ArrowDown,
-        F1 => KeyCode::F1,
-        F2 => KeyCode::F2,
-        F3 => KeyCode::F3,
-        F4 => KeyCode::F4,
-        F5 => KeyCode::F5,
-        F6 => KeyCode::F6,
-        F7 => KeyCode::F7,
-        F8 => KeyCode::F8,
-        F9 => KeyCode::F9,
-        F10 => KeyCode::F10,
-        F11 => KeyCode::F11,
-        F12 => KeyCode::F12,
-        LShift | RShift => KeyCode::Shift,
-        LControl | RControl => KeyCode::Control,
-        LAlt | RAlt => KeyCode::Alt,
-        LWin | RWin => KeyCode::Meta,
-        Minus => KeyCode::Minus,
-        Equals => KeyCode::Equals,
-        LBracket => KeyCode::LeftBracket,
-        RBracket => KeyCode::RightBracket,
-        Backslash => KeyCode::Backslash,
-        Semicolon => KeyCode::Semicolon,
-        Apostrophe => KeyCode::Apostrophe,
-        Comma => KeyCode::Comma,
-        Period => KeyCode::Period,
-        Slash => KeyCode::Slash,
-        Grave => KeyCode::GraveAccent,
-        Numpad0 => KeyCode::Numpad0,
-        Numpad1 => KeyCode::Numpad1,
-        Numpad2 => KeyCode::Numpad2,
-        Numpad3 => KeyCode::Numpad3,
-        Numpad4 => KeyCode::Numpad4,
-        Numpad5 => KeyCode::Numpad5,
-        Numpad6 => KeyCode::Numpad6,
-        Numpad7 => KeyCode::Numpad7,
-        Numpad8 => KeyCode::Numpad8,
-        Numpad9 => KeyCode::Numpad9,
-        NumpadAdd => KeyCode::NumpadAdd,
-        NumpadSubtract => KeyCode::NumpadSubtract,
-        NumpadMultiply => KeyCode::NumpadMultiply,
-        NumpadDivide => KeyCode::NumpadDivide,
-        NumpadDecimal => KeyCode::NumpadDecimal,
-        NumpadEnter => KeyCode::NumpadEnter,
-        Capital => KeyCode::CapsLock,
-        Numlock => KeyCode::NumLock,
-        Scroll => KeyCode::ScrollLock,
-        Snapshot => KeyCode::PrintScreen,
-        Pause => KeyCode::Pause,
-        Apps => KeyCode::Menu,
-        _ => KeyCode::Undefined,
-    }
+macro_rules! map_keycodes {
+    ( $( $vk:ident => $kc:ident ),* $(,)?; $( $same:ident ),* $(,)? ) => {
+        impl From<VirtualKeyCode> for KeyCode {
+            fn from(key: VirtualKeyCode) -> Self {
+                use VirtualKeyCode::*;
+                match key {
+                    $( $vk => KeyCode::$kc, )*
+                    $( $same => KeyCode::$same, )*
+                    _ => KeyCode::Undefined,
+                }
+            }
+        }
+    };
+}
+
+map_keycodes! {
+    Key0 => Digit0,
+    Key1 => Digit1,
+    Key2 => Digit2,
+    Key3 => Digit3,
+    Key4 => Digit4,
+    Key5 => Digit5,
+    Key6 => Digit6,
+    Key7 => Digit7,
+    Key8 => Digit8,
+    Key9 => Digit9,
+    Return => Enter,
+    Back => Backspace,
+    LShift => Shift,
+    RShift => Shift,
+    LControl => Control,
+    RControl => Control,
+    LAlt => Alt,
+    RAlt => Alt,
+    LWin => Meta,
+    RWin => Meta,
+    LBracket => LeftBracket,
+    RBracket => RightBracket,
+    Grave => GraveAccent,
+    Left => ArrowLeft,
+    Right => ArrowRight,
+    Up => ArrowUp,
+    Down => ArrowDown,
+    Capital => CapsLock,
+    Numlock => NumLock,
+    Scroll => ScrollLock,
+    Snapshot => PrintScreen,
+    Apps => Menu;
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
+    Escape, Space, Tab, Insert, Delete, Home, End, PageUp, PageDown,
+    Minus, Equals, Backslash, Semicolon, Apostrophe, Comma, Period, Slash,
+    Numpad0, Numpad1, Numpad2, Numpad3, Numpad4, Numpad5, Numpad6, Numpad7, Numpad8, Numpad9,
+    NumpadAdd, NumpadSubtract, NumpadMultiply, NumpadDivide, NumpadDecimal, NumpadEnter,
+    Pause,
 }
 
 pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
@@ -529,12 +479,17 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
             WindowEvent::CloseRequested => Some(Event {
                 event_type: EventType::Quit,
                 source: EventSource::Window,
-                payload: Payload { press: PressPayload { key: KeyCode::Undefined, previous: EventType::Unknown } },
+                payload: Payload {
+                    press: PressPayload {
+                        key: KeyCode::Undefined,
+                        previous: EventType::Unknown,
+                    },
+                },
                 timestamp: 0,
             }),
             WindowEvent::KeyboardInput { input, .. } => {
                 if let Some(k) = input.virtual_keycode {
-                    let key = map_virtual_keycode(k);
+                    let key = KeyCode::from(k);
                     let et = if input.state == ElementState::Pressed {
                         EventType::Pressed
                     } else {
@@ -543,7 +498,12 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
                     Some(Event {
                         event_type: et,
                         source: EventSource::Key,
-                        payload: Payload { press: PressPayload { key, previous: EventType::Unknown } },
+                        payload: Payload {
+                            press: PressPayload {
+                                key,
+                                previous: EventType::Unknown,
+                            },
+                        },
                         timestamp: 0,
                     })
                 } else {
@@ -553,7 +513,11 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
             WindowEvent::CursorMoved { position, .. } => Some(Event {
                 event_type: EventType::Motion2D,
                 source: EventSource::Mouse,
-                payload: Payload { motion2d: Motion2DPayload { motion: vec2(position.x as f32, position.y as f32) } },
+                payload: Payload {
+                    motion2d: Motion2DPayload {
+                        motion: vec2(position.x as f32, position.y as f32),
+                    },
+                },
                 timestamp: 0,
             }),
             WindowEvent::MouseInput { state, button, .. } => {
@@ -587,7 +551,9 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
                 Some(Event {
                     event_type: EventType::Motion2D,
                     source: EventSource::Mouse,
-                    payload: Payload { motion2d: Motion2DPayload { motion: vec2(x, y) } },
+                    payload: Payload {
+                        motion2d: Motion2DPayload { motion: vec2(x, y) },
+                    },
                     timestamp: 0,
                 })
             }
@@ -631,7 +597,10 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
             }
             _ => None,
         },
-        WEvent::DeviceEvent { event: DeviceEvent::MouseMotion { delta }, .. } => Some(Event {
+        WEvent::DeviceEvent {
+            event: DeviceEvent::MouseMotion { delta },
+            ..
+        } => Some(Event {
             event_type: EventType::Motion2D,
             source: EventSource::Mouse,
             payload: Payload {
@@ -641,7 +610,10 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
             },
             timestamp: 0,
         }),
-        WEvent::DeviceEvent { event: DeviceEvent::MouseWheel { delta }, .. } => {
+        WEvent::DeviceEvent {
+            event: DeviceEvent::MouseWheel { delta },
+            ..
+        } => {
             let (x, y) = match delta {
                 MouseScrollDelta::LineDelta(x, y) => (*x as f32, *y as f32),
                 MouseScrollDelta::PixelDelta(pos) => (pos.x as f32, pos.y as f32),
@@ -650,14 +622,15 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
                 event_type: EventType::Motion2D,
                 source: EventSource::Mouse,
                 payload: Payload {
-                    motion2d: Motion2DPayload {
-                        motion: vec2(x, y),
-                    },
+                    motion2d: Motion2DPayload { motion: vec2(x, y) },
                 },
                 timestamp: 0,
             })
         }
-        WEvent::DeviceEvent { event: DeviceEvent::Button { state, .. }, .. } => {
+        WEvent::DeviceEvent {
+            event: DeviceEvent::Button { state, .. },
+            ..
+        } => {
             let et = if *state == ElementState::Pressed {
                 EventType::Pressed
             } else {
@@ -675,7 +648,10 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
                 timestamp: 0,
             })
         }
-        WEvent::DeviceEvent { event: DeviceEvent::Motion { axis, value }, .. } => Some(Event {
+        WEvent::DeviceEvent {
+            event: DeviceEvent::Motion { axis, value },
+            ..
+        } => Some(Event {
             event_type: EventType::Joystick,
             source: EventSource::Gamepad,
             payload: Payload {
@@ -686,5 +662,20 @@ pub fn from_winit_event(event: &WEvent<'_, ()>) -> Option<Event> {
             timestamp: 0,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use winit::event::VirtualKeyCode as VK;
+
+    #[test]
+    fn converts_basic_keys() {
+        assert_eq!(KeyCode::from(VK::A), KeyCode::A);
+        assert_eq!(KeyCode::from(VK::Key5), KeyCode::Digit5);
+        assert_eq!(KeyCode::from(VK::LShift), KeyCode::Shift);
+        assert_eq!(KeyCode::from(VK::NumpadAdd), KeyCode::NumpadAdd);
+        assert_eq!(KeyCode::from(VK::AbntC1), KeyCode::Undefined);
     }
 }


### PR DESCRIPTION
## Summary
- add macro and From<VirtualKeyCode> implementation for KeyCode
- default unknown keys to KeyCode::Undefined and update event conversion
- test mapping for representative keys

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688fb9ee4338832ab3d303e6cbcffc20