### PR TITLE
Add audio subsystem with FFI access

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -11,6 +11,7 @@ extern "C" {
 struct MeshiEngine;
 struct MeshiEngineInfo;
 struct RenderEngine;
+struct AudioEngine;
 struct FFIMeshObjectInfo;
 struct MeshObject;
 struct DirectionalLightInfo;
@@ -35,6 +36,7 @@ void meshi_destroy_engine(struct MeshiEngine* engine);
 void meshi_register_event_callback(struct MeshiEngine* engine, void* user_data, MeshiEventCallback cb);
 float meshi_update(struct MeshiEngine* engine);
 struct RenderEngine* meshi_get_graphics_system(struct MeshiEngine* engine);
+struct AudioEngine* meshi_get_audio_system(struct MeshiEngine* engine);
 
 // Graphics
 struct Handle meshi_gfx_create_renderable(struct RenderEngine* render, const struct FFIMeshObjectInfo* info);

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,0 +1,42 @@
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, Default)]
+#[repr(C)]
+pub enum AudioBackend {
+    #[default]
+    Dummy,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AudioEngineInfo {
+    pub sample_rate: u32,
+    pub channels: u32,
+    pub backend: AudioBackend,
+}
+
+impl Default for AudioEngineInfo {
+    fn default() -> Self {
+        Self {
+            sample_rate: 48_000,
+            channels: 2,
+            backend: AudioBackend::Dummy,
+        }
+    }
+}
+
+#[repr(C)]
+#[allow(dead_code)]
+pub struct AudioEngine {
+    info: AudioEngineInfo,
+}
+
+impl AudioEngine {
+    pub fn new(info: &AudioEngineInfo) -> Self {
+        info!(
+            "Initializing Audio Engine: {} Hz, {} channels",
+            info.sample_rate, info.channels
+        );
+        Self { info: *info }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod audio;
 mod object;
 pub mod physics;
 pub mod render;
 mod utils;
+use audio::{AudioEngine, AudioEngineInfo};
 use dashi::utils::Handle;
 use glam::{Mat4, Vec3};
 use object::{FFIMeshObjectInfo, MeshObject};
@@ -36,6 +38,7 @@ pub struct MeshiEngine {
     name: String,
     render: RenderEngine,
     physics: Box<PhysicsSimulation>,
+    audio: AudioEngine,
     frame_timer: Timer,
 }
 
@@ -68,6 +71,7 @@ impl MeshiEngine {
             })
             .expect("failed to initialize render engine"),
             physics: Box::new(PhysicsSimulation::new(&Default::default())),
+            audio: AudioEngine::new(&AudioEngineInfo::default()),
             frame_timer: Timer::new(),
             name: appname.to_string(),
         }))
@@ -142,7 +146,8 @@ pub extern "C" fn meshi_make_engine_headless(
 pub extern "C" fn meshi_destroy_engine(engine: *mut MeshiEngine) {
     if !engine.is_null() {
         unsafe {
-            // Take ownership and ensure the engine is fully dropped before returning.
+            // Take ownership and ensure the engine and all subsystems are fully dropped
+            // (render, physics and audio) before returning.
             let _engine = Box::from_raw(engine);
             // `_engine` is dropped here when it goes out of scope.
         }
@@ -379,6 +384,24 @@ pub extern "C" fn meshi_gfx_capture_mouse(render: *mut RenderEngine, value: i32)
         return;
     }
     unsafe { &mut *render }.set_capture_mouse(value != 0);
+}
+
+////////////////////////////////////////////
+///////////////////AUDIO////////////////////
+////////////////////////////////////////////
+////////////////////////////////////////////
+////////////////////////////////////////////
+////////////////////////////////////////////
+/// Obtain a mutable pointer to the engine's audio system.
+///
+/// # Safety
+/// `engine` must be a valid engine pointer.
+#[no_mangle]
+pub extern "C" fn meshi_get_audio_system(engine: *mut MeshiEngine) -> *mut AudioEngine {
+    if engine.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe { &mut (*engine).audio }
 }
 
 ////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- add basic audio engine types
- integrate audio engine into `MeshiEngine`
- expose audio system through `meshi_get_audio_system` and update C header

## Testing
- `cargo fmt -- src/lib.rs src/audio/mod.rs`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbbcc0fe8832a9a5cef9823eb1fdb