### PR TITLE
Add rigid body velocity accessor to FFI

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -59,6 +59,8 @@ void meshi_physx_release_rigid_body(struct PhysicsSimulation* physics, const str
 void meshi_physx_apply_force_to_rigid_body(struct PhysicsSimulation* physics, const struct Handle* h, const struct ForceApplyInfo* info);
 int32_t meshi_physx_set_rigid_body_transform(struct PhysicsSimulation* physics, const struct Handle* h, const struct ActorStatus* info);
 int32_t meshi_physx_get_rigid_body_status(struct PhysicsSimulation* physics, const struct Handle* h, struct ActorStatus* out_status);
+// Returns the current velocity of a rigid body or a zero vector on failure.
+struct Vec3 meshi_physx_get_rigid_body_velocity(struct PhysicsSimulation* physics, const struct Handle* h);
 int32_t meshi_physx_set_collision_shape(struct PhysicsSimulation* physics, const struct Handle* h, const struct CollisionShape* shape);
 size_t meshi_physx_get_contacts(struct PhysicsSimulation* physics, struct ContactInfo* out_contacts, size_t max);
 struct CollisionShape meshi_physx_collision_shape_sphere(float radius);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -519,6 +519,27 @@ pub extern "C" fn meshi_physx_get_rigid_body_status(
     }
 }
 
+/// Retrieve the current velocity of a rigid body.
+///
+/// If any pointer is invalid or the handle does not reference a valid body,
+/// a zero vector is returned.
+///
+/// # Safety
+/// `physics` and `h` must be valid, non-null pointers.
+#[no_mangle]
+pub extern "C" fn meshi_physx_get_rigid_body_velocity(
+    physics: *mut PhysicsSimulation,
+    h: *const Handle<physics::RigidBody>,
+) -> Vec3 {
+    if physics.is_null() || h.is_null() {
+        return Vec3::ZERO;
+    }
+
+    unsafe { &*physics }
+        .get_rigid_body_velocity(unsafe { *h })
+        .unwrap_or(Vec3::ZERO)
+}
+
 /// Set the collision shape for a rigid body.
 ///
 /// # Safety

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -29,7 +29,10 @@ fn main() {
         rotation: Quat::IDENTITY,
     };
     unsafe {
-        assert_eq!(meshi_physx_set_rigid_body_transform(physics, &rb, &new_status), 1);
+        assert_eq!(
+            meshi_physx_set_rigid_body_transform(physics, &rb, &new_status),
+            1
+        );
     }
     let mut out = ActorStatus::default();
     unsafe {
@@ -37,6 +40,10 @@ fn main() {
     }
     assert_eq!(out.position, new_status.position);
     assert_eq!(out.rotation, new_status.rotation);
+
+    // Newly added FFI: retrieve rigid body velocity
+    let vel = unsafe { meshi_physx_get_rigid_body_velocity(physics, &rb) };
+    assert_eq!(vel, Vec3::ZERO);
 
     unsafe {
         meshi_physx_release_rigid_body(physics, &rb);


### PR DESCRIPTION
## Summary
- expose `meshi_physx_get_rigid_body_velocity` to retrieve a rigid body's velocity safely via FFI
- document the new function in the C header
- test velocity retrieval through FFI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688fc47983b0832a9a51badfbe7c0fac