### PR TITLE
refactor: remove unused dead_code allowances

### DIFF
--- a/src/render/event.rs
+++ b/src/render/event.rs
@@ -1,6 +1,5 @@
 use std::os::raw::c_uint;
 
-#[allow(dead_code)]
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum EventType {
@@ -12,7 +11,6 @@ pub enum EventType {
     Motion2D = 5,
 }
 
-#[allow(dead_code)]
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum EventSource {
@@ -24,7 +22,6 @@ pub enum EventSource {
     Window = 5,
 }
 
-#[allow(dead_code)]
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum KeyCode {


### PR DESCRIPTION
## Summary
- remove dead_code allowances from event enums

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688fc8cf9174832a8a237cfc52422fe4