### PR TITLE
Add basic audio source management

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -38,6 +38,16 @@ float meshi_update(struct MeshiEngine* engine);
 struct RenderEngine* meshi_get_graphics_system(struct MeshiEngine* engine);
 struct AudioEngine* meshi_get_audio_system(struct MeshiEngine* engine);
 
+// Audio
+struct Handle meshi_audio_create_source(struct AudioEngine* audio, const char* path);
+void meshi_audio_destroy_source(struct AudioEngine* audio, struct Handle h);
+void meshi_audio_play(struct AudioEngine* audio, struct Handle h);
+void meshi_audio_pause(struct AudioEngine* audio, struct Handle h);
+void meshi_audio_stop(struct AudioEngine* audio, struct Handle h);
+void meshi_audio_set_looping(struct AudioEngine* audio, struct Handle h, int32_t looping);
+void meshi_audio_set_volume(struct AudioEngine* audio, struct Handle h, float volume);
+void meshi_audio_set_pitch(struct AudioEngine* audio, struct Handle h, float pitch);
+
 // Graphics
 struct Handle meshi_gfx_create_renderable(struct RenderEngine* render, const struct FFIMeshObjectInfo* info);
 struct Handle meshi_gfx_create_cube(struct RenderEngine* render);

--- a/include/meshi/meshi_types.h
+++ b/include/meshi/meshi_types.h
@@ -261,4 +261,5 @@ using MeshiMeshObjectHandle = MeshiHandle;
 using MeshiDirectionalLightHandle = MeshiHandle;
 using MeshiMaterialHandle = MeshiHandle;
 using MeshiRigidBodyHandle = MeshiHandle;
+using MeshiAudioSourceHandle = MeshiHandle;
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,3 +1,4 @@
+use dashi::utils::{Handle, Pool};
 use tracing::info;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -29,6 +30,7 @@ impl Default for AudioEngineInfo {
 #[allow(dead_code)]
 pub struct AudioEngine {
     info: AudioEngineInfo,
+    sources: Pool<AudioSource>,
 }
 
 impl AudioEngine {
@@ -37,6 +39,89 @@ impl AudioEngine {
             "Initializing Audio Engine: {} Hz, {} channels",
             info.sample_rate, info.channels
         );
-        Self { info: *info }
+        Self {
+            info: *info,
+            sources: Default::default(),
+        }
+    }
+
+    pub fn create_source(&mut self, path: &str) -> Handle<AudioSource> {
+        self.sources
+            .insert(AudioSource::new(path))
+            .unwrap_or_default()
+    }
+
+    pub fn destroy_source(&mut self, h: Handle<AudioSource>) {
+        self.sources.release(h);
+    }
+
+    fn get_source_mut(&mut self, h: Handle<AudioSource>) -> Option<&mut AudioSource> {
+        self.sources.get_mut_ref(h)
+    }
+
+    pub fn play(&mut self, h: Handle<AudioSource>) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.state = PlaybackState::Playing;
+        }
+    }
+
+    pub fn pause(&mut self, h: Handle<AudioSource>) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.state = PlaybackState::Paused;
+        }
+    }
+
+    pub fn stop(&mut self, h: Handle<AudioSource>) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.state = PlaybackState::Stopped;
+        }
+    }
+
+    pub fn set_looping(&mut self, h: Handle<AudioSource>, looping: bool) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.looping = looping;
+        }
+    }
+
+    pub fn set_volume(&mut self, h: Handle<AudioSource>, volume: f32) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.volume = volume;
+        }
+    }
+
+    pub fn set_pitch(&mut self, h: Handle<AudioSource>, pitch: f32) {
+        if let Some(s) = self.get_source_mut(h) {
+            s.pitch = pitch;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum PlaybackState {
+    Stopped,
+    Playing,
+    Paused,
+}
+
+#[repr(C)]
+pub struct AudioSource {
+    #[allow(dead_code)]
+    path: String,
+    looping: bool,
+    volume: f32,
+    pitch: f32,
+    state: PlaybackState,
+}
+
+impl AudioSource {
+    fn new(path: &str) -> Self {
+        Self {
+            path: path.to_string(),
+            looping: false,
+            volume: 1.0,
+            pitch: 1.0,
+            state: PlaybackState::Stopped,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod object;
 pub mod physics;
 pub mod render;
 mod utils;
-use audio::{AudioEngine, AudioEngineInfo};
+use audio::{AudioEngine, AudioEngineInfo, AudioSource};
 use dashi::utils::Handle;
 use glam::{Mat4, Vec3};
 use object::{FFIMeshObjectInfo, MeshObject};
@@ -402,6 +402,94 @@ pub extern "C" fn meshi_get_audio_system(engine: *mut MeshiEngine) -> *mut Audio
         return std::ptr::null_mut();
     }
     unsafe { &mut (*engine).audio }
+}
+
+/// Create an audio source from a file path.
+#[no_mangle]
+pub extern "C" fn meshi_audio_create_source(
+    audio: *mut AudioEngine,
+    path: *const c_char,
+) -> Handle<AudioSource> {
+    if audio.is_null() || path.is_null() {
+        return Handle::default();
+    }
+    let p = unsafe { CStr::from_ptr(path) }.to_str().unwrap_or("");
+    unsafe { &mut *audio }.create_source(p)
+}
+
+/// Destroy an audio source and free its resources.
+#[no_mangle]
+pub extern "C" fn meshi_audio_destroy_source(audio: *mut AudioEngine, h: Handle<AudioSource>) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.destroy_source(h);
+}
+
+/// Begin playback for an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_play(audio: *mut AudioEngine, h: Handle<AudioSource>) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.play(h);
+}
+
+/// Pause playback for an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_pause(audio: *mut AudioEngine, h: Handle<AudioSource>) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.pause(h);
+}
+
+/// Stop playback for an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_stop(audio: *mut AudioEngine, h: Handle<AudioSource>) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.stop(h);
+}
+
+/// Set whether an audio source loops when played.
+#[no_mangle]
+pub extern "C" fn meshi_audio_set_looping(
+    audio: *mut AudioEngine,
+    h: Handle<AudioSource>,
+    looping: i32,
+) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.set_looping(h, looping != 0);
+}
+
+/// Adjust the playback volume for an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_set_volume(
+    audio: *mut AudioEngine,
+    h: Handle<AudioSource>,
+    volume: c_float,
+) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.set_volume(h, volume as f32);
+}
+
+/// Adjust the playback pitch for an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_set_pitch(
+    audio: *mut AudioEngine,
+    h: Handle<AudioSource>,
+    pitch: c_float,
+) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.set_pitch(h, pitch as f32);
 }
 
 ////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- implement AudioSource pooling and playback control
- add FFI helpers for creating, controlling, and destroying audio sources
- expose audio source API in public headers

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688fc8df97cc832a9c7c10a50a68169c