### PR TITLE
Fix database context compile error

### DIFF
--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -1,5 +1,5 @@
 pub mod error;
-use dashi::{utils::Handle, Buffer, BufferInfo, BufferUsage, MemoryVisibility};
+use dashi::{utils::Handle, Buffer, BufferInfo, BufferUsage, Context, MemoryVisibility};
 use tracing::info;
 
 pub use error::*;
@@ -289,6 +289,7 @@ mod tests {
         Database {
             base_path: path.to_string(),
             geometry: HashMap::new(),
+            ctx: std::ptr::null_mut(),
             textures: HashMap::new(),
             _fonts: HashMap::new(),
         }


### PR DESCRIPTION
## Summary
- fix missing `Context` import for `Database`
- create minimal test database with null context pointer

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688ffeffa2c0832ab7cc841650e74efb