### PR TITLE
Add audio source state retrieval

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -44,6 +44,7 @@ void meshi_audio_destroy_source(struct AudioEngine* audio, struct Handle h);
 void meshi_audio_play(struct AudioEngine* audio, struct Handle h);
 void meshi_audio_pause(struct AudioEngine* audio, struct Handle h);
 void meshi_audio_stop(struct AudioEngine* audio, struct Handle h);
+int32_t meshi_audio_get_state(struct AudioEngine* audio, struct Handle h);
 void meshi_audio_set_looping(struct AudioEngine* audio, struct Handle h, int32_t looping);
 void meshi_audio_set_volume(struct AudioEngine* audio, struct Handle h, float volume);
 void meshi_audio_set_pitch(struct AudioEngine* audio, struct Handle h, float pitch);

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,9 +1,5 @@
 use dashi::utils::{Handle, Pool};
-use std::{
-    collections::VecDeque,
-    fs::File,
-    io::{Read},
-};
+use std::{collections::VecDeque, fs::File, io::Read};
 use tracing::info;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -64,6 +60,10 @@ impl AudioEngine {
 
     fn get_source_mut(&mut self, h: Handle<AudioSource>) -> Option<&mut AudioSource> {
         self.sources.get_mut_ref(h)
+    }
+
+    pub fn get_state(&self, h: Handle<AudioSource>) -> Option<PlaybackState> {
+        self.sources.get_ref(h).map(|s| s.state)
     }
 
     pub fn play(&mut self, h: Handle<AudioSource>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod object;
 pub mod physics;
 pub mod render;
 mod utils;
-use audio::{AudioEngine, AudioEngineInfo, AudioSource, StreamingSource};
+use audio::{AudioEngine, AudioEngineInfo, AudioSource, PlaybackState, StreamingSource};
 use dashi::utils::Handle;
 use glam::{Mat4, Vec3};
 pub use object::FFIMeshObjectInfo;
@@ -453,6 +453,20 @@ pub extern "C" fn meshi_audio_stop(audio: *mut AudioEngine, h: Handle<AudioSourc
         return;
     }
     unsafe { &mut *audio }.stop(h);
+}
+
+/// Get the current playback state of an audio source.
+#[no_mangle]
+pub extern "C" fn meshi_audio_get_state(
+    audio: *mut AudioEngine,
+    h: Handle<AudioSource>,
+) -> PlaybackState {
+    if audio.is_null() {
+        return PlaybackState::Stopped;
+    }
+    unsafe { &mut *audio }
+        .get_state(h)
+        .unwrap_or(PlaybackState::Stopped)
 }
 
 /// Set whether an audio source loops when played.

--- a/tests/audio_state.rs
+++ b/tests/audio_state.rs
@@ -1,0 +1,18 @@
+use meshi::audio::{AudioEngine, AudioEngineInfo, PlaybackState};
+
+#[test]
+fn audio_state_transitions() {
+    let mut audio = AudioEngine::new(&AudioEngineInfo::default());
+    let h = audio.create_source("dummy");
+
+    assert_eq!(audio.get_state(h), Some(PlaybackState::Stopped));
+
+    audio.play(h);
+    assert_eq!(audio.get_state(h), Some(PlaybackState::Playing));
+
+    audio.pause(h);
+    assert_eq!(audio.get_state(h), Some(PlaybackState::Paused));
+
+    audio.stop(h);
+    assert_eq!(audio.get_state(h), Some(PlaybackState::Stopped));
+}


### PR DESCRIPTION
## Summary
- expose audio source playback state via `AudioEngine::get_state`
- add C-ABI function `meshi_audio_get_state`
- test audio playback state transitions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68900c224174832aa232990292365413