### PR TITLE
Add audio bus volume controls and finished callbacks

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -9,6 +9,7 @@ extern "C" {
 #endif
 
 typedef void (*MeshiEventCallback)(struct MeshiEvent*, void*);
+typedef void (*MeshiAudioFinishedCallback)(MeshiAudioSourceHandle, void*);
 
 // Engine
 struct MeshiEngine* meshi_make_engine(const struct MeshiEngineInfo* info);
@@ -43,6 +44,8 @@ void meshi_audio_set_listener_transform(
     struct AudioEngine* audio,
     const struct Mat4* transform,
     struct Vec3 velocity);
+void meshi_audio_set_bus_volume(struct MeshiAudioEngine* audio, MeshiAudioBusHandle h, float volume);
+void meshi_audio_register_finished_callback(struct MeshiAudioEngine* audio, void* user_data, MeshiAudioFinishedCallback cb);
 
 // Graphics
 MeshiMeshObjectHandle meshi_gfx_create_renderable(struct MeshiRenderEngine* render, const MeshiFFIMeshObjectInfo* info);

--- a/include/meshi/meshi_types.h
+++ b/include/meshi/meshi_types.h
@@ -263,4 +263,5 @@ using MeshiDirectionalLightHandle = MeshiHandle;
 using MeshiMaterialHandle = MeshiHandle;
 using MeshiRigidBodyHandle = MeshiHandle;
 using MeshiAudioSourceHandle = MeshiHandle;
+using MeshiAudioBusHandle = MeshiHandle;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,10 @@ mod object;
 pub mod physics;
 pub mod render;
 mod utils;
-use audio::{AudioEngine, AudioEngineInfo, AudioSource, PlaybackState, StreamingSource};
+use audio::{
+    AudioEngine, AudioEngineInfo, AudioSource, Bus, FinishedCallback, PlaybackState,
+    StreamingSource,
+};
 use dashi::utils::Handle;
 use glam::{Mat4, Vec3};
 pub use object::FFIMeshObjectInfo;
@@ -568,6 +571,32 @@ pub extern "C" fn meshi_audio_update_stream(
     }
     let slice = unsafe { std::slice::from_raw_parts_mut(out_samples, max) };
     unsafe { &mut *audio }.update_stream(h, slice)
+}
+
+/// Set the volume for an audio bus.
+#[no_mangle]
+pub extern "C" fn meshi_audio_set_bus_volume(
+    audio: *mut AudioEngine,
+    h: Handle<Bus>,
+    volume: c_float,
+) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.set_bus_volume(h, volume as f32);
+}
+
+/// Register a callback invoked when a source finishes playback.
+#[no_mangle]
+pub extern "C" fn meshi_audio_register_finished_callback(
+    audio: *mut AudioEngine,
+    user_data: *mut c_void,
+    cb: FinishedCallback,
+) {
+    if audio.is_null() {
+        return;
+    }
+    unsafe { &mut *audio }.register_finished_callback(cb, user_data);
 }
 
 ////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- introduce hierarchical audio buses with per-bus volume and finished playback callbacks
- expose `meshi_audio_set_bus_volume` and `meshi_audio_register_finished_callback` in the FFI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689029c30d98832abbac646df691b79e