### PR TITLE
Expose audio playback state via FFI

### DIFF
--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -26,6 +26,7 @@ void meshi_audio_destroy_source(struct MeshiAudioEngine* audio, MeshiAudioSource
 void meshi_audio_play(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h);
 void meshi_audio_pause(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h);
 void meshi_audio_stop(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h);
+MeshiPlaybackState meshi_audio_get_state(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h);
 void meshi_audio_set_looping(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h, int32_t looping);
 void meshi_audio_set_volume(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h, float volume);
 void meshi_audio_set_pitch(struct MeshiAudioEngine* audio, MeshiAudioSourceHandle h, float pitch);

--- a/include/meshi/meshi_types.h
+++ b/include/meshi/meshi_types.h
@@ -231,6 +231,12 @@ enum class MeshiCollisionShapeType : std::uint32_t {
     Box = 1,
 };
 
+enum class MeshiPlaybackState : std::uint32_t {
+    Stopped = 0,
+    Playing = 1,
+    Paused = 2,
+};
+
 struct alignas(16) MeshiCollisionShape {
     MeshiVec3 dimensions;
     float radius;

--- a/tests/audio_state.rs
+++ b/tests/audio_state.rs
@@ -1,18 +1,21 @@
 use meshi::audio::{AudioEngine, AudioEngineInfo, PlaybackState};
+use meshi::{
+    meshi_audio_get_state, meshi_audio_pause, meshi_audio_play, meshi_audio_stop,
+};
 
 #[test]
 fn audio_state_transitions() {
     let mut audio = AudioEngine::new(&AudioEngineInfo::default());
     let h = audio.create_source("dummy");
 
-    assert_eq!(audio.get_state(h), Some(PlaybackState::Stopped));
+    assert_eq!(meshi_audio_get_state(&mut audio, h), PlaybackState::Stopped);
 
-    audio.play(h);
-    assert_eq!(audio.get_state(h), Some(PlaybackState::Playing));
+    meshi_audio_play(&mut audio, h);
+    assert_eq!(meshi_audio_get_state(&mut audio, h), PlaybackState::Playing);
 
-    audio.pause(h);
-    assert_eq!(audio.get_state(h), Some(PlaybackState::Paused));
+    meshi_audio_pause(&mut audio, h);
+    assert_eq!(meshi_audio_get_state(&mut audio, h), PlaybackState::Paused);
 
-    audio.stop(h);
-    assert_eq!(audio.get_state(h), Some(PlaybackState::Stopped));
+    meshi_audio_stop(&mut audio, h);
+    assert_eq!(meshi_audio_get_state(&mut audio, h), PlaybackState::Stopped);
 }


### PR DESCRIPTION
## Summary
- add MeshiPlaybackState enum and expose meshi_audio_get_state in C header
- test playback state transitions through FFI

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68903301a854832a84e0fd68c153e378