### PR TITLE
Use TryFrom for FFI mesh info

### DIFF
--- a/examples/simple_render.rs
+++ b/examples/simple_render.rs
@@ -35,7 +35,9 @@ fn main() {
         material: tex.as_ptr(),
         transform: Mat4::IDENTITY,
     };
-    render.register_mesh_object(&info);
+    render
+        .register_mesh_object(&info)
+        .expect("failed to register mesh object");
 
     // Run a small render loop to display the scene.
     for _ in 0..120 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,10 @@ pub extern "C" fn meshi_gfx_create_renderable(
     if render.is_null() || info.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.register_mesh_object(unsafe { &*info })
+    match unsafe { &mut *render }.register_mesh_object(unsafe { &*info }) {
+        Ok(handle) => handle,
+        Err(_) => Handle::default(),
+    }
 }
 
 #[no_mangle]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,9 @@ use database::{Database, Error as DatabaseError};
 use glam::{Mat4, Vec4};
 use tracing::{info, warn};
 
-use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo, MeshTarget};
+use crate::object::{
+    Error as MeshObjectError, FFIMeshObjectInfo, MeshObject, MeshObjectInfo, MeshTarget,
+};
 use crate::render::database::geometry_primitives::{self, CubePrimitiveInfo, SpherePrimitiveInfo};
 mod canvas;
 pub mod config;
@@ -241,12 +243,13 @@ impl RenderEngine {
         self.directional_lights.release(handle);
     }
 
-    pub fn register_mesh_object(&mut self, info: &FFIMeshObjectInfo) -> Handle<MeshObject> {
-        let info: MeshObjectInfo = info.into();
-        let object = info
-            .make_object(&mut self.database)
-            .expect("failed to create mesh object");
-        self.mesh_objects.insert(object).unwrap()
+    pub fn register_mesh_object(
+        &mut self,
+        info: &FFIMeshObjectInfo,
+    ) -> Result<Handle<MeshObject>, MeshObjectError> {
+        let info = MeshObjectInfo::try_from(info)?;
+        let object = info.make_object(&mut self.database)?;
+        Ok(self.mesh_objects.insert(object).unwrap())
     }
 
     pub fn release_mesh_object(&mut self, handle: Handle<MeshObject>) {

--- a/tests/gfx_create_renderable_err.rs
+++ b/tests/gfx_create_renderable_err.rs
@@ -1,0 +1,31 @@
+use dashi::utils::Handle;
+use glam::Mat4;
+use meshi::*;
+use std::ffi::CString;
+
+#[test]
+fn invalid_info_returns_default_handle() {
+    let name = CString::new("test").unwrap();
+    let loc = CString::new(".").unwrap();
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 1,
+    };
+    let engine = unsafe { meshi_make_engine(&info) };
+    assert!(!engine.is_null());
+    let render = unsafe { meshi_get_graphics_system(engine) };
+    assert!(!render.is_null());
+
+    let bad = FFIMeshObjectInfo {
+        mesh: std::ptr::null(),
+        material: std::ptr::null(),
+        transform: Mat4::IDENTITY,
+    };
+    let handle = unsafe { meshi_gfx_create_renderable(render, &bad) };
+    let default = Handle::<()>::default();
+    assert_eq!(handle.slot, default.slot);
+    assert_eq!(handle.generation, default.generation);
+
+    unsafe { meshi_destroy_engine(engine) };
+}


### PR DESCRIPTION
## Summary
- add an `Error` type for mesh object creation and use `TryFrom` for `FFIMeshObjectInfo`
- bubble mesh object creation errors through `register_mesh_object` and FFI `meshi_gfx_create_renderable`
- test handling of invalid FFI mesh object info

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68903304eb44832a8a50e674b9cb05d7