### PR TITLE
Make rodio audio backend always enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,7 @@ unzip3 = "1.0.0"
 base64 = "0.22.1"
 winit = "0.26"
 rayon = "1.10"
-rodio = { version = "0.17", optional = true }
-
-[features]
-default = []
-rodio_backend = ["rodio"]
+rodio = { version = "0.17" }
 
 [dev-dependencies]
 tempfile = "3"
@@ -50,7 +46,6 @@ path = "examples/simple_render.rs"
 [[example]]
 name = "audio_playback"
 path = "examples/audio_playback.rs"
-required-features = ["rodio_backend"]
 
 [[test]]
 name = "engine"

--- a/tests/audio_playback.rs
+++ b/tests/audio_playback.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "rodio_backend")]
-
 use meshi::audio::{AudioBackend, AudioEngine, AudioEngineInfo};
 use serial_test::serial;
 use std::{path::Path, thread::sleep, time::Duration};


### PR DESCRIPTION
## Summary
- remove feature gating around rodio and include it as a default dependency
- compile rodio audio backend and tests unconditionally

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6890af6ce344832a97e611a31d0e3cbc