### PR TITLE
Remove silent default material fallback

### DIFF
--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,7 +1,7 @@
 use crate::render::database::{self, Database, MeshResource};
 use dashi::utils::Handle;
 use glam::Mat4;
-use tracing::info;
+use tracing::{info, warn};
 
 use std::ffi::{c_char, CStr};
 use std::fmt;
@@ -88,10 +88,10 @@ impl MeshObjectInfo {
         );
 
         let mesh = db.fetch_mesh(self.mesh)?;
-        let material = match db.fetch_material(self.material) {
-            Ok(mat) => mat,
-            Err(_) => db.fetch_material("DEFAULT")?,
-        };
+        let material = db.fetch_material(self.material).map_err(|e| {
+            warn!("failed to fetch material '{}': {}", self.material, e);
+            e
+        })?;
 
         let targets = vec![MeshTarget {
             mesh: mesh.clone(),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -263,9 +263,31 @@ impl RenderEngine {
             material: "MESHI_CUBE",
             transform: Mat4::IDENTITY,
         };
-        let object = info
-            .make_object(&mut self.database)
-            .expect("failed to create mesh object");
+        let object = match info.make_object(&mut self.database) {
+            Ok(obj) => obj,
+            Err(e) => {
+                warn!(
+                    "failed to create mesh object '{}': {}; falling back to default material",
+                    info.mesh, e
+                );
+                let mesh = self
+                    .database
+                    .fetch_mesh(info.mesh)
+                    .expect("failed to fetch mesh");
+                let material = self
+                    .database
+                    .fetch_material("DEFAULT")
+                    .expect("failed to fetch default material");
+                MeshObject {
+                    targets: vec![MeshTarget {
+                        mesh: mesh.clone(),
+                        material,
+                    }],
+                    mesh,
+                    transform: info.transform,
+                }
+            }
+        };
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -294,9 +316,31 @@ impl RenderEngine {
             material: "MESHI_SPHERE",
             transform: Mat4::IDENTITY,
         };
-        let object = info
-            .make_object(&mut self.database)
-            .expect("failed to create mesh object");
+        let object = match info.make_object(&mut self.database) {
+            Ok(obj) => obj,
+            Err(e) => {
+                warn!(
+                    "failed to create mesh object '{}': {}; falling back to default material",
+                    info.mesh, e
+                );
+                let mesh = self
+                    .database
+                    .fetch_mesh(info.mesh)
+                    .expect("failed to fetch mesh");
+                let material = self
+                    .database
+                    .fetch_material("DEFAULT")
+                    .expect("failed to fetch default material");
+                MeshObject {
+                    targets: vec![MeshTarget {
+                        mesh: mesh.clone(),
+                        material,
+                    }],
+                    mesh,
+                    transform: info.transform,
+                }
+            }
+        };
         self.mesh_objects.insert(object).unwrap()
     }
 
@@ -325,9 +369,31 @@ impl RenderEngine {
             material: "MESHI_TRIANGLE",
             transform: Mat4::IDENTITY,
         };
-        let object = info
-            .make_object(&mut self.database)
-            .expect("failed to create mesh object");
+        let object = match info.make_object(&mut self.database) {
+            Ok(obj) => obj,
+            Err(e) => {
+                warn!(
+                    "failed to create mesh object '{}': {}; falling back to default material",
+                    info.mesh, e
+                );
+                let mesh = self
+                    .database
+                    .fetch_mesh(info.mesh)
+                    .expect("failed to fetch mesh");
+                let material = self
+                    .database
+                    .fetch_material("DEFAULT")
+                    .expect("failed to fetch default material");
+                MeshObject {
+                    targets: vec![MeshTarget {
+                        mesh: mesh.clone(),
+                        material,
+                    }],
+                    mesh,
+                    transform: info.transform,
+                }
+            }
+        };
         self.mesh_objects.insert(object).unwrap()
     }
 


### PR DESCRIPTION
## Summary
- warn and return error when fetching a material fails instead of silently using `DEFAULT`
- fallback to default material in engine helpers with a warning

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689180f755ac832aaeff189f7525a457