### PR TITLE
feat(render): add cylinder plane cone primitives

### DIFF
--- a/examples/ffi_init.rs
+++ b/examples/ffi_init.rs
@@ -1,5 +1,8 @@
 use glam::{Mat4, Vec4};
-use meshi::render::{database::geometry_primitives::CubePrimitiveInfo, DirectionalLightInfo};
+use meshi::render::{
+    database::geometry_primitives::{CubePrimitiveInfo, CylinderPrimitiveInfo},
+    DirectionalLightInfo,
+};
 use meshi::*;
 use std::ffi::CString;
 
@@ -11,6 +14,13 @@ fn main() {
     let info = CubePrimitiveInfo { size: 2.0 };
     let cube = unsafe { meshi_gfx_create_cube_ex(render, &info) };
     unsafe { meshi_gfx_set_renderable_transform(render, cube, &Mat4::IDENTITY) };
+    let cyl_info = CylinderPrimitiveInfo {
+        radius: 1.0,
+        height: 2.0,
+        segments: 16,
+    };
+    let cylinder = unsafe { meshi_gfx_create_cylinder_ex(render, &cyl_info) };
+    unsafe { meshi_gfx_set_renderable_transform(render, cylinder, &Mat4::IDENTITY) };
 
     let light_info = DirectionalLightInfo {
         direction: Vec4::new(0.0, -1.0, 0.0, 0.0),

--- a/include/meshi/meshi.h
+++ b/include/meshi/meshi.h
@@ -52,6 +52,9 @@ void meshi_audio_register_finished_callback(struct MeshiAudioEngine* audio, void
 MeshiMeshObjectHandle meshi_gfx_create_renderable(struct MeshiRenderEngine* render, const MeshiFFIMeshObjectInfo* info);
 MeshiMeshObjectHandle meshi_gfx_create_cube(struct MeshiRenderEngine* render);
 MeshiMeshObjectHandle meshi_gfx_create_sphere(struct MeshiRenderEngine* render);
+MeshiMeshObjectHandle meshi_gfx_create_cylinder(struct MeshiRenderEngine* render);
+MeshiMeshObjectHandle meshi_gfx_create_plane(struct MeshiRenderEngine* render);
+MeshiMeshObjectHandle meshi_gfx_create_cone(struct MeshiRenderEngine* render);
 MeshiMeshObjectHandle meshi_gfx_create_triangle(struct MeshiRenderEngine* render);
 void meshi_gfx_set_renderable_transform(struct MeshiRenderEngine* render, MeshiMeshObjectHandle h, const MeshiMat4* transform);
 MeshiDirectionalLightHandle meshi_gfx_create_directional_light(struct MeshiRenderEngine* render, const MeshiDirectionalLightInfo* info);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,63 @@ pub extern "C" fn meshi_gfx_create_sphere_ex(
 }
 
 #[no_mangle]
+pub extern "C" fn meshi_gfx_create_cylinder(render: *mut RenderEngine) -> Handle<MeshObject> {
+    if render.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_cylinder()
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_cylinder_ex(
+    render: *mut RenderEngine,
+    info: *const render::database::geometry_primitives::CylinderPrimitiveInfo,
+) -> Handle<MeshObject> {
+    if render.is_null() || info.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_cylinder_ex(unsafe { &*info })
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_plane(render: *mut RenderEngine) -> Handle<MeshObject> {
+    if render.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_plane()
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_plane_ex(
+    render: *mut RenderEngine,
+    info: *const render::database::geometry_primitives::PlanePrimitiveInfo,
+) -> Handle<MeshObject> {
+    if render.is_null() || info.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_plane_ex(unsafe { &*info })
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_cone(render: *mut RenderEngine) -> Handle<MeshObject> {
+    if render.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_cone()
+}
+
+#[no_mangle]
+pub extern "C" fn meshi_gfx_create_cone_ex(
+    render: *mut RenderEngine,
+    info: *const render::database::geometry_primitives::ConePrimitiveInfo,
+) -> Handle<MeshObject> {
+    if render.is_null() || info.is_null() {
+        return Handle::default();
+    }
+    unsafe { &mut *render }.create_cone_ex(unsafe { &*info })
+}
+
+#[no_mangle]
 pub extern "C" fn meshi_gfx_create_triangle(render: *mut RenderEngine) -> Handle<MeshObject> {
     if render.is_null() {
         return Handle::default();

--- a/src/render/database/geometry.rs
+++ b/src/render/database/geometry.rs
@@ -25,6 +25,18 @@ pub fn load_primitives(ctx: &mut Context) -> HashMap<String, MeshResource> {
         "MESHI_SPHERE".to_string(),
         geometry_primitives::make_sphere(&Default::default(), ctx),
     );
+    geometry.insert(
+        "MESHI_CYLINDER".to_string(),
+        geometry_primitives::make_cylinder(&Default::default(), ctx),
+    );
+    geometry.insert(
+        "MESHI_PLANE".to_string(),
+        geometry_primitives::make_plane(&Default::default(), ctx),
+    );
+    geometry.insert(
+        "MESHI_CONE".to_string(),
+        geometry_primitives::make_cone(&Default::default(), ctx),
+    );
     geometry
 }
 

--- a/src/render/database/geometry_primitives.rs
+++ b/src/render/database/geometry_primitives.rs
@@ -299,3 +299,362 @@ pub fn make_sphere(info: &SpherePrimitiveInfo, ctx: &mut dashi::Context) -> Mesh
         num_indices: indices.len(),
     }
 }
+
+#[repr(C)]
+pub struct CylinderPrimitiveInfo {
+    pub radius: f32,
+    pub height: f32,
+    pub segments: u32,
+}
+
+impl Default for CylinderPrimitiveInfo {
+    fn default() -> Self {
+        Self {
+            radius: 1.0,
+            height: 1.0,
+            segments: 32,
+        }
+    }
+}
+
+pub fn make_cylinder(info: &CylinderPrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+    let CylinderPrimitiveInfo {
+        radius,
+        height,
+        segments,
+    } = *info;
+
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+
+    // Side vertices
+    for i in 0..=segments {
+        let theta = (i as f32) * 2.0 * std::f32::consts::PI / (segments as f32);
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        let u = i as f32 / segments as f32;
+        vertices.push(Vertex {
+            position: Vec4::new(x, height * 0.5, z, 1.0),
+            normal: Vec4::new(x / radius, 0.0, z / radius, 0.0),
+            tex_coords: Vec2::new(u, 1.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+        vertices.push(Vertex {
+            position: Vec4::new(x, -height * 0.5, z, 1.0),
+            normal: Vec4::new(x / radius, 0.0, z / radius, 0.0),
+            tex_coords: Vec2::new(u, 0.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+    }
+
+    for i in 0..segments {
+        let top1 = 2 * i as u32;
+        let bottom1 = top1 + 1;
+        let top2 = 2 * (i + 1) as u32;
+        let bottom2 = top2 + 1;
+
+        indices.push(top1);
+        indices.push(bottom1);
+        indices.push(top2);
+
+        indices.push(top2);
+        indices.push(bottom1);
+        indices.push(bottom2);
+    }
+
+    let top_start = vertices.len();
+    for i in 0..segments {
+        let theta = (i as f32) * 2.0 * std::f32::consts::PI / (segments as f32);
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        vertices.push(Vertex {
+            position: Vec4::new(x, height * 0.5, z, 1.0),
+            normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+            tex_coords: Vec2::ZERO,
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+    }
+    let top_center = vertices.len() as u32;
+    vertices.push(Vertex {
+        position: Vec4::new(0.0, height * 0.5, 0.0, 1.0),
+        normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+        tex_coords: Vec2::ZERO,
+        joint_ids: IVec4::ZERO,
+        joints: Vec4::ZERO,
+        color: Vec4::ZERO,
+    });
+    for i in 0..segments {
+        let current = top_start as u32 + i;
+        let next = top_start as u32 + ((i + 1) % segments);
+        indices.push(top_center);
+        indices.push(current);
+        indices.push(next);
+    }
+
+    let bottom_start = vertices.len();
+    for i in 0..segments {
+        let theta = (i as f32) * 2.0 * std::f32::consts::PI / (segments as f32);
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        vertices.push(Vertex {
+            position: Vec4::new(x, -height * 0.5, z, 1.0),
+            normal: Vec4::new(0.0, -1.0, 0.0, 0.0),
+            tex_coords: Vec2::ZERO,
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+    }
+    let bottom_center = vertices.len() as u32;
+    vertices.push(Vertex {
+        position: Vec4::new(0.0, -height * 0.5, 0.0, 1.0),
+        normal: Vec4::new(0.0, -1.0, 0.0, 0.0),
+        tex_coords: Vec2::ZERO,
+        joint_ids: IVec4::ZERO,
+        joints: Vec4::ZERO,
+        color: Vec4::ZERO,
+    });
+    for i in 0..segments {
+        let current = bottom_start as u32 + i;
+        let next = bottom_start as u32 + ((i + 1) % segments);
+        indices.push(bottom_center);
+        indices.push(next);
+        indices.push(current);
+    }
+
+    let vertex_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Cylinder Vertices".to_string(),
+            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::VERTEX,
+            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    let index_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Cylinder Indices".to_string(),
+            byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::INDEX,
+            initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    info!("Registering Default Cylinder Mesh..");
+    MeshResource {
+        name: "CYLINDER".to_string(),
+        vertices: vertex_buffer,
+        num_vertices: vertices.len(),
+        indices: index_buffer,
+        num_indices: indices.len(),
+    }
+}
+
+#[repr(C)]
+pub struct PlanePrimitiveInfo {
+    pub size: f32,
+}
+
+impl Default for PlanePrimitiveInfo {
+    fn default() -> Self {
+        Self { size: 1.0 }
+    }
+}
+
+pub fn make_plane(info: &PlanePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+    let size = info.size;
+
+    let vertices: [Vertex; 4] = [
+        Vertex {
+            position: Vec4::new(-size, 0.0, -size, 1.0),
+            normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+            tex_coords: Vec2::new(0.0, 0.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        },
+        Vertex {
+            position: Vec4::new(size, 0.0, -size, 1.0),
+            normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+            tex_coords: Vec2::new(1.0, 0.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        },
+        Vertex {
+            position: Vec4::new(size, 0.0, size, 1.0),
+            normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+            tex_coords: Vec2::new(1.0, 1.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        },
+        Vertex {
+            position: Vec4::new(-size, 0.0, size, 1.0),
+            normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+            tex_coords: Vec2::new(0.0, 1.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        },
+    ];
+
+    const INDICES: [u32; 6] = [0, 1, 2, 2, 3, 0];
+
+    let vertex_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Plane Vertices".to_string(),
+            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::VERTEX,
+            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    let index_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Plane Indices".to_string(),
+            byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::INDEX,
+            initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    info!("Registering Default Plane Mesh..");
+    MeshResource {
+        name: "PLANE".to_string(),
+        vertices: vertex_buffer,
+        num_vertices: vertices.len(),
+        indices: index_buffer,
+        num_indices: INDICES.len(),
+    }
+}
+
+#[repr(C)]
+pub struct ConePrimitiveInfo {
+    pub radius: f32,
+    pub height: f32,
+    pub segments: u32,
+}
+
+impl Default for ConePrimitiveInfo {
+    fn default() -> Self {
+        Self {
+            radius: 1.0,
+            height: 1.0,
+            segments: 32,
+        }
+    }
+}
+
+pub fn make_cone(info: &ConePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+    let ConePrimitiveInfo {
+        radius,
+        height,
+        segments,
+    } = *info;
+
+    let mut vertices = Vec::new();
+    let mut indices = Vec::new();
+
+    for i in 0..segments {
+        let theta = (i as f32) * 2.0 * std::f32::consts::PI / (segments as f32);
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        let normal = Vec4::new(x, radius / height, z, 0.0).normalize();
+        vertices.push(Vertex {
+            position: Vec4::new(x, -height * 0.5, z, 1.0),
+            normal,
+            tex_coords: Vec2::new(i as f32 / segments as f32, 0.0),
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+    }
+    let apex_index = vertices.len() as u32;
+    vertices.push(Vertex {
+        position: Vec4::new(0.0, height * 0.5, 0.0, 1.0),
+        normal: Vec4::new(0.0, 1.0, 0.0, 0.0),
+        tex_coords: Vec2::new(0.5, 1.0),
+        joint_ids: IVec4::ZERO,
+        joints: Vec4::ZERO,
+        color: Vec4::ZERO,
+    });
+
+    for i in 0..segments {
+        let current = i;
+        let next = (i + 1) % segments;
+        indices.push(current);
+        indices.push(next);
+        indices.push(apex_index);
+    }
+
+    let base_start = vertices.len();
+    for i in 0..segments {
+        let theta = (i as f32) * 2.0 * std::f32::consts::PI / (segments as f32);
+        let x = radius * theta.cos();
+        let z = radius * theta.sin();
+        vertices.push(Vertex {
+            position: Vec4::new(x, -height * 0.5, z, 1.0),
+            normal: Vec4::new(0.0, -1.0, 0.0, 0.0),
+            tex_coords: Vec2::ZERO,
+            joint_ids: IVec4::ZERO,
+            joints: Vec4::ZERO,
+            color: Vec4::ZERO,
+        });
+    }
+    let base_center = vertices.len() as u32;
+    vertices.push(Vertex {
+        position: Vec4::new(0.0, -height * 0.5, 0.0, 1.0),
+        normal: Vec4::new(0.0, -1.0, 0.0, 0.0),
+        tex_coords: Vec2::ZERO,
+        joint_ids: IVec4::ZERO,
+        joints: Vec4::ZERO,
+        color: Vec4::ZERO,
+    });
+    for i in 0..segments {
+        let current = base_start as u32 + i;
+        let next = base_start as u32 + ((i + 1) % segments);
+        indices.push(base_center);
+        indices.push(next);
+        indices.push(current);
+    }
+
+    let vertex_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Cone Vertices".to_string(),
+            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::VERTEX,
+            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    let index_buffer = ctx
+        .make_buffer(&BufferInfo {
+            debug_name: &"Cone Indices".to_string(),
+            byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
+            visibility: MemoryVisibility::Gpu,
+            usage: BufferUsage::INDEX,
+            initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
+        })
+        .unwrap();
+
+    info!("Registering Default Cone Mesh..");
+    MeshResource {
+        name: "CONE".to_string(),
+        vertices: vertex_buffer,
+        num_vertices: vertices.len(),
+        indices: index_buffer,
+        num_indices: indices.len(),
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -11,7 +11,10 @@ use tracing::{info, warn};
 use crate::object::{
     Error as MeshObjectError, FFIMeshObjectInfo, MeshObject, MeshObjectInfo, MeshTarget,
 };
-use crate::render::database::geometry_primitives::{self, CubePrimitiveInfo, SpherePrimitiveInfo};
+use crate::render::database::geometry_primitives::{
+    self, ConePrimitiveInfo, CubePrimitiveInfo, CylinderPrimitiveInfo, PlanePrimitiveInfo,
+    SpherePrimitiveInfo,
+};
 mod canvas;
 pub mod config;
 pub mod database;
@@ -303,6 +306,99 @@ impl RenderEngine {
     pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
         let mesh = geometry_primitives::make_sphere(info, ctx);
+        let material = self
+            .database
+            .fetch_material("DEFAULT")
+            .expect("failed to fetch default material");
+        let target = MeshTarget {
+            mesh: mesh.clone(),
+            material,
+        };
+        let object = MeshObject {
+            targets: vec![target],
+            mesh,
+            transform: Mat4::IDENTITY,
+        };
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_cylinder(&mut self) -> Handle<MeshObject> {
+        let info = MeshObjectInfo {
+            mesh: "MESHI_CYLINDER",
+            material: "MESHI_CYLINDER",
+            transform: Mat4::IDENTITY,
+        };
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_cylinder_ex(&mut self, info: &CylinderPrimitiveInfo) -> Handle<MeshObject> {
+        let ctx = self.ctx.as_mut().expect("render context not initialized");
+        let mesh = geometry_primitives::make_cylinder(info, ctx);
+        let material = self
+            .database
+            .fetch_material("DEFAULT")
+            .expect("failed to fetch default material");
+        let target = MeshTarget {
+            mesh: mesh.clone(),
+            material,
+        };
+        let object = MeshObject {
+            targets: vec![target],
+            mesh,
+            transform: Mat4::IDENTITY,
+        };
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_plane(&mut self) -> Handle<MeshObject> {
+        let info = MeshObjectInfo {
+            mesh: "MESHI_PLANE",
+            material: "MESHI_PLANE",
+            transform: Mat4::IDENTITY,
+        };
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_plane_ex(&mut self, info: &PlanePrimitiveInfo) -> Handle<MeshObject> {
+        let ctx = self.ctx.as_mut().expect("render context not initialized");
+        let mesh = geometry_primitives::make_plane(info, ctx);
+        let material = self
+            .database
+            .fetch_material("DEFAULT")
+            .expect("failed to fetch default material");
+        let target = MeshTarget {
+            mesh: mesh.clone(),
+            material,
+        };
+        let object = MeshObject {
+            targets: vec![target],
+            mesh,
+            transform: Mat4::IDENTITY,
+        };
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_cone(&mut self) -> Handle<MeshObject> {
+        let info = MeshObjectInfo {
+            mesh: "MESHI_CONE",
+            material: "MESHI_CONE",
+            transform: Mat4::IDENTITY,
+        };
+        let object = info
+            .make_object(&mut self.database)
+            .expect("failed to create mesh object");
+        self.mesh_objects.insert(object).unwrap()
+    }
+
+    pub fn create_cone_ex(&mut self, info: &ConePrimitiveInfo) -> Handle<MeshObject> {
+        let ctx = self.ctx.as_mut().expect("render context not initialized");
+        let mesh = geometry_primitives::make_cone(info, ctx);
         let material = self
             .database
             .fetch_material("DEFAULT")

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,6 +1,9 @@
 use glam::Mat4;
 use meshi::render::{
-    database::geometry_primitives::{CubePrimitiveInfo, SpherePrimitiveInfo},
+    database::geometry_primitives::{
+        ConePrimitiveInfo, CubePrimitiveInfo, CylinderPrimitiveInfo, PlanePrimitiveInfo,
+        SpherePrimitiveInfo,
+    },
     RenderBackend,
 };
 use meshi::*;
@@ -32,5 +35,19 @@ fn main() {
         rings: 8,
     };
     unsafe { meshi_gfx_create_sphere_ex(render, &sphere_info) };
+    let cylinder_info = CylinderPrimitiveInfo {
+        radius: 1.0,
+        height: 2.0,
+        segments: 8,
+    };
+    unsafe { meshi_gfx_create_cylinder_ex(render, &cylinder_info) };
+    let plane_info = PlanePrimitiveInfo { size: 1.0 };
+    unsafe { meshi_gfx_create_plane_ex(render, &plane_info) };
+    let cone_info = ConePrimitiveInfo {
+        radius: 1.0,
+        height: 2.0,
+        segments: 8,
+    };
+    unsafe { meshi_gfx_create_cone_ex(render, &cone_info) };
     unsafe { meshi_update(engine) };
 }


### PR DESCRIPTION
## Summary
- add cylinder, plane, and cone primitive builders
- expose new primitive creation helpers in the render API and FFI
- showcase cylinder usage in examples and tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689180fa9010832a930e0047eaf3b776