### PR TITLE
Handle pool insertion failures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,10 @@ pub extern "C" fn meshi_gfx_create_cube(render: *mut RenderEngine) -> Handle<Mes
     if render.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.create_cube()
+    match unsafe { &mut *render }.create_cube() {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]
@@ -244,7 +247,10 @@ pub extern "C" fn meshi_gfx_create_cube_ex(
     if render.is_null() || info.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.create_cube_ex(unsafe { &*info })
+    match unsafe { &mut *render }.create_cube_ex(unsafe { &*info }) {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]
@@ -252,7 +258,10 @@ pub extern "C" fn meshi_gfx_create_sphere(render: *mut RenderEngine) -> Handle<M
     if render.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.create_sphere()
+    match unsafe { &mut *render }.create_sphere() {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]
@@ -263,7 +272,10 @@ pub extern "C" fn meshi_gfx_create_sphere_ex(
     if render.is_null() || info.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.create_sphere_ex(unsafe { &*info })
+    match unsafe { &mut *render }.create_sphere_ex(unsafe { &*info }) {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]
@@ -271,7 +283,10 @@ pub extern "C" fn meshi_gfx_create_triangle(render: *mut RenderEngine) -> Handle
     if render.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.create_triangle()
+    match unsafe { &mut *render }.create_triangle() {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]
@@ -315,7 +330,10 @@ pub extern "C" fn meshi_gfx_create_directional_light(
     if render.is_null() || info.is_null() {
         return Handle::default();
     }
-    unsafe { &mut *render }.register_directional_light(unsafe { &*info })
+    match unsafe { &mut *render }.register_directional_light(unsafe { &*info }) {
+        Some(handle) => handle,
+        None => Handle::default(),
+    }
 }
 
 #[no_mangle]

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -23,6 +23,7 @@ pub struct MeshObjectInfo {
 pub enum Error {
     InvalidString,
     Database(database::Error),
+    PoolFull,
 }
 
 impl fmt::Display for Error {
@@ -30,6 +31,7 @@ impl fmt::Display for Error {
         match self {
             Error::InvalidString => write!(f, "invalid string pointer"),
             Error::Database(err) => err.fmt(f),
+            Error::PoolFull => write!(f, "object pool full"),
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -212,12 +212,12 @@ impl RenderEngine {
     pub fn register_directional_light(
         &mut self,
         info: &DirectionalLightInfo,
-    ) -> Handle<DirectionalLight> {
+    ) -> Option<Handle<DirectionalLight>> {
         let light = DirectionalLight {
             transform: Mat4::IDENTITY,
             info: *info,
         };
-        self.directional_lights.insert(light).unwrap()
+        self.directional_lights.insert(light)
     }
 
     pub fn set_directional_light_transform(
@@ -250,14 +250,16 @@ impl RenderEngine {
     ) -> Result<Handle<MeshObject>, MeshObjectError> {
         let info = MeshObjectInfo::try_from(info)?;
         let object = info.make_object(&mut self.database)?;
-        Ok(self.mesh_objects.insert(object).unwrap())
+        self.mesh_objects
+            .insert(object)
+            .ok_or(MeshObjectError::PoolFull)
     }
 
     pub fn release_mesh_object(&mut self, handle: Handle<MeshObject>) {
         self.mesh_objects.release(handle);
     }
 
-    pub fn create_cube(&mut self) -> Handle<MeshObject> {
+    pub fn create_cube(&mut self) -> Option<Handle<MeshObject>> {
         let info = MeshObjectInfo {
             mesh: "MESHI_CUBE",
             material: "MESHI_CUBE",
@@ -266,10 +268,10 @@ impl RenderEngine {
         let object = info
             .make_object(&mut self.database)
             .expect("failed to create mesh object");
-        self.mesh_objects.insert(object).unwrap()
+        self.mesh_objects.insert(object)
     }
 
-    pub fn create_cube_ex(&mut self, info: &CubePrimitiveInfo) -> Handle<MeshObject> {
+    pub fn create_cube_ex(&mut self, info: &CubePrimitiveInfo) -> Option<Handle<MeshObject>> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
         let mesh = geometry_primitives::make_cube(info, ctx);
         let material = self
@@ -285,10 +287,10 @@ impl RenderEngine {
             mesh,
             transform: Mat4::IDENTITY,
         };
-        self.mesh_objects.insert(object).unwrap()
+        self.mesh_objects.insert(object)
     }
 
-    pub fn create_sphere(&mut self) -> Handle<MeshObject> {
+    pub fn create_sphere(&mut self) -> Option<Handle<MeshObject>> {
         let info = MeshObjectInfo {
             mesh: "MESHI_SPHERE",
             material: "MESHI_SPHERE",
@@ -297,10 +299,10 @@ impl RenderEngine {
         let object = info
             .make_object(&mut self.database)
             .expect("failed to create mesh object");
-        self.mesh_objects.insert(object).unwrap()
+        self.mesh_objects.insert(object)
     }
 
-    pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Handle<MeshObject> {
+    pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Option<Handle<MeshObject>> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
         let mesh = geometry_primitives::make_sphere(info, ctx);
         let material = self
@@ -316,10 +318,10 @@ impl RenderEngine {
             mesh,
             transform: Mat4::IDENTITY,
         };
-        self.mesh_objects.insert(object).unwrap()
+        self.mesh_objects.insert(object)
     }
 
-    pub fn create_triangle(&mut self) -> Handle<MeshObject> {
+    pub fn create_triangle(&mut self) -> Option<Handle<MeshObject>> {
         let info = MeshObjectInfo {
             mesh: "MESHI_TRIANGLE",
             material: "MESHI_TRIANGLE",
@@ -328,7 +330,7 @@ impl RenderEngine {
         let object = info
             .make_object(&mut self.database)
             .expect("failed to create mesh object");
-        self.mesh_objects.insert(object).unwrap()
+        self.mesh_objects.insert(object)
     }
 
     pub fn set_mesh_object_transform(


### PR DESCRIPTION
## Summary
- avoid panics on `Pool::insert` by returning `Option` or `MeshObjectError::PoolFull`
- update FFI wrappers to return default handles on insertion failure

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689181003eb0832aaa0095cba1c0c7cb