### PR TITLE
Handle GPU allocation failures in primitive creation

### DIFF
--- a/src/render/database/geometry.rs
+++ b/src/render/database/geometry.rs
@@ -5,6 +5,7 @@ use gltf::Gltf;
 
 use super::{geometry_primitives, MeshResource};
 use dashi::Context;
+use tracing::warn;
 
 /// Load the default set of mesh primitives into a map keyed by their names.
 ///
@@ -15,27 +16,45 @@ pub fn load_primitives(ctx: &mut Context) -> HashMap<String, MeshResource> {
     let mut geometry = HashMap::new();
     geometry.insert(
         "MESHI_TRIANGLE".to_string(),
-        geometry_primitives::make_triangle(&Default::default(), ctx),
+        geometry_primitives::make_triangle(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate triangle primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry.insert(
         "MESHI_CUBE".to_string(),
-        geometry_primitives::make_cube(&Default::default(), ctx),
+        geometry_primitives::make_cube(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate cube primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry.insert(
         "MESHI_SPHERE".to_string(),
-        geometry_primitives::make_sphere(&Default::default(), ctx),
+        geometry_primitives::make_sphere(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate sphere primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry.insert(
         "MESHI_CYLINDER".to_string(),
-        geometry_primitives::make_cylinder(&Default::default(), ctx),
+        geometry_primitives::make_cylinder(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate cylinder primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry.insert(
         "MESHI_PLANE".to_string(),
-        geometry_primitives::make_plane(&Default::default(), ctx),
+        geometry_primitives::make_plane(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate plane primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry.insert(
         "MESHI_CONE".to_string(),
-        geometry_primitives::make_cone(&Default::default(), ctx),
+        geometry_primitives::make_cone(&Default::default(), ctx).unwrap_or_else(|e| {
+            warn!("failed to allocate cone primitive: {:?}", e);
+            MeshResource::default()
+        }),
     );
     geometry
 }

--- a/src/render/database/geometry_primitives.rs
+++ b/src/render/database/geometry_primitives.rs
@@ -25,7 +25,10 @@ impl Default for CubePrimitiveInfo {
     }
 }
 
-pub fn make_cube(info: &CubePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_cube(
+    info: &CubePrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let size = info.size;
 
     let cvertices: [Vertex; 8] = [
@@ -107,34 +110,30 @@ pub fn make_cube(info: &CubePrimitiveInfo, ctx: &mut dashi::Context) -> MeshReso
         4, 5, 1, 1, 0, 4,
     ];
 
-    let vertices = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cube Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * cvertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { cvertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertices = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cube Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * cvertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { cvertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let indices = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cube Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let indices = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cube Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Cube Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "CUBE".to_string(),
         vertices,
         num_vertices: cvertices.len(),
         indices,
         num_indices: INDICES.len(),
-    }
+    })
 }
 
 #[repr(C)]
@@ -148,7 +147,10 @@ impl Default for TrianglePrimitiveInfo {
     }
 }
 
-pub fn make_triangle(info: &TrianglePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_triangle(
+    info: &TrianglePrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let size = info.size;
     let tvertices: [Vertex; 3] = [
         Vertex {
@@ -179,34 +181,30 @@ pub fn make_triangle(info: &TrianglePrimitiveInfo, ctx: &mut dashi::Context) -> 
 
     const INDICES: [u32; 3] = [0, 1, 2];
 
-    let vertices = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Triangle Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * tvertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { tvertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertices = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Triangle Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * tvertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { tvertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let indices = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Triangle Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let indices = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Triangle Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Triangle Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "TRIANGLE".to_string(),
         vertices,
         num_vertices: tvertices.len(),
         indices,
         num_indices: INDICES.len(),
-    }
+    })
 }
 
 #[repr(C)]
@@ -226,7 +224,10 @@ impl Default for SpherePrimitiveInfo {
     }
 }
 
-pub fn make_sphere(info: &SpherePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_sphere(
+    info: &SpherePrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let SpherePrimitiveInfo {
         radius,
         segments,
@@ -270,34 +271,30 @@ pub fn make_sphere(info: &SpherePrimitiveInfo, ctx: &mut dashi::Context) -> Mesh
         }
     }
 
-    let vertex_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Sphere Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertex_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Sphere Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let index_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Sphere Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let index_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Sphere Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Sphere Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "SPHERE".to_string(),
         vertices: vertex_buffer,
         num_vertices: vertices.len(),
         indices: index_buffer,
         num_indices: indices.len(),
-    }
+    })
 }
 
 #[repr(C)]
@@ -317,7 +314,10 @@ impl Default for CylinderPrimitiveInfo {
     }
 }
 
-pub fn make_cylinder(info: &CylinderPrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_cylinder(
+    info: &CylinderPrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let CylinderPrimitiveInfo {
         radius,
         height,
@@ -428,34 +428,30 @@ pub fn make_cylinder(info: &CylinderPrimitiveInfo, ctx: &mut dashi::Context) -> 
         indices.push(current);
     }
 
-    let vertex_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cylinder Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertex_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cylinder Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let index_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cylinder Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let index_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cylinder Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Cylinder Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "CYLINDER".to_string(),
         vertices: vertex_buffer,
         num_vertices: vertices.len(),
         indices: index_buffer,
         num_indices: indices.len(),
-    }
+    })
 }
 
 #[repr(C)]
@@ -469,7 +465,10 @@ impl Default for PlanePrimitiveInfo {
     }
 }
 
-pub fn make_plane(info: &PlanePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_plane(
+    info: &PlanePrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let size = info.size;
 
     let vertices: [Vertex; 4] = [
@@ -509,34 +508,30 @@ pub fn make_plane(info: &PlanePrimitiveInfo, ctx: &mut dashi::Context) -> MeshRe
 
     const INDICES: [u32; 6] = [0, 1, 2, 2, 3, 0];
 
-    let vertex_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Plane Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertex_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Plane Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let index_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Plane Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let index_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Plane Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * INDICES.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { INDICES.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Plane Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "PLANE".to_string(),
         vertices: vertex_buffer,
         num_vertices: vertices.len(),
         indices: index_buffer,
         num_indices: INDICES.len(),
-    }
+    })
 }
 
 #[repr(C)]
@@ -556,7 +551,10 @@ impl Default for ConePrimitiveInfo {
     }
 }
 
-pub fn make_cone(info: &ConePrimitiveInfo, ctx: &mut dashi::Context) -> MeshResource {
+pub fn make_cone(
+    info: &ConePrimitiveInfo,
+    ctx: &mut dashi::Context,
+) -> Result<MeshResource, dashi::GPUError> {
     let ConePrimitiveInfo {
         radius,
         height,
@@ -629,32 +627,28 @@ pub fn make_cone(info: &ConePrimitiveInfo, ctx: &mut dashi::Context) -> MeshReso
         indices.push(current);
     }
 
-    let vertex_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cone Vertices".to_string(),
-            byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::VERTEX,
-            initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let vertex_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cone Vertices".to_string(),
+        byte_size: (std::mem::size_of::<Vertex>() * vertices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::VERTEX,
+        initial_data: Some(unsafe { vertices.as_slice().align_to::<u8>().1 }),
+    })?;
 
-    let index_buffer = ctx
-        .make_buffer(&BufferInfo {
-            debug_name: &"Cone Indices".to_string(),
-            byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
-            visibility: MemoryVisibility::Gpu,
-            usage: BufferUsage::INDEX,
-            initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
-        })
-        .unwrap();
+    let index_buffer = ctx.make_buffer(&BufferInfo {
+        debug_name: &"Cone Indices".to_string(),
+        byte_size: (std::mem::size_of::<u32>() * indices.len()) as u32,
+        visibility: MemoryVisibility::Gpu,
+        usage: BufferUsage::INDEX,
+        initial_data: Some(unsafe { indices.as_slice().align_to::<u8>().1 }),
+    })?;
 
     info!("Registering Default Cone Mesh..");
-    MeshResource {
+    Ok(MeshResource {
         name: "CONE".to_string(),
         vertices: vertex_buffer,
         num_vertices: vertices.len(),
         indices: index_buffer,
         num_indices: indices.len(),
-    }
+    })
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,7 +4,7 @@ use dashi::{
     utils::{Handle, Pool},
     *,
 };
-use database::{Database, Error as DatabaseError};
+use database::{Database, Error as DatabaseError, MeshResource};
 use glam::{Mat4, Vec4};
 use tracing::{info, warn};
 
@@ -296,7 +296,10 @@ impl RenderEngine {
 
     pub fn create_cube_ex(&mut self, info: &CubePrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cube(info, ctx);
+        let mesh = geometry_primitives::make_cube(info, ctx).unwrap_or_else(|e| {
+            warn!("failed to create cube primitive: {:?}", e);
+            MeshResource::default()
+        });
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -349,7 +352,10 @@ impl RenderEngine {
 
     pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_sphere(info, ctx);
+        let mesh = geometry_primitives::make_sphere(info, ctx).unwrap_or_else(|e| {
+            warn!("failed to create sphere primitive: {:?}", e);
+            MeshResource::default()
+        });
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -380,7 +386,10 @@ impl RenderEngine {
 
     pub fn create_cylinder_ex(&mut self, info: &CylinderPrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cylinder(info, ctx);
+        let mesh = geometry_primitives::make_cylinder(info, ctx).unwrap_or_else(|e| {
+            warn!("failed to create cylinder primitive: {:?}", e);
+            MeshResource::default()
+        });
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -411,7 +420,10 @@ impl RenderEngine {
 
     pub fn create_plane_ex(&mut self, info: &PlanePrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_plane(info, ctx);
+        let mesh = geometry_primitives::make_plane(info, ctx).unwrap_or_else(|e| {
+            warn!("failed to create plane primitive: {:?}", e);
+            MeshResource::default()
+        });
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -442,7 +454,10 @@ impl RenderEngine {
 
     pub fn create_cone_ex(&mut self, info: &ConePrimitiveInfo) -> Handle<MeshObject> {
         let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cone(info, ctx);
+        let mesh = geometry_primitives::make_cone(info, ctx).unwrap_or_else(|e| {
+            warn!("failed to create cone primitive: {:?}", e);
+            MeshResource::default()
+        });
         let material = self
             .database
             .fetch_material("DEFAULT")


### PR DESCRIPTION
## Summary
- Return `Result<MeshResource, GPUError>` from geometry primitive builders and propagate errors with `?`
- Log failures and fall back to default meshes when primitive allocation fails
- Update `RenderEngine` helpers to handle primitive creation errors

## Testing
- `cargo test -q > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_689259d614c8832aa716575a606e18db