### PR TITLE
Add region-based streaming manager

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audio;
 mod object;
 pub mod physics;
 pub mod render;
+pub mod streaming;
 mod utils;
 use audio::{
     AudioEngine, AudioEngineInfo, AudioSource, Bus, FinishedCallback, PlaybackState,

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -1,0 +1,139 @@
+use std::collections::HashSet;
+use std::ffi::CString;
+
+use dashi::utils::Handle;
+use glam::Vec3;
+use tracing::warn;
+
+use crate::object::{FFIMeshObjectInfo, MeshObject, MeshObjectInfo};
+use crate::render::database::Database;
+use crate::render::RenderEngine;
+
+#[derive(Clone, Copy)]
+pub struct AABB {
+    pub min: Vec3,
+    pub max: Vec3,
+}
+
+impl AABB {
+    pub fn contains(&self, point: Vec3) -> bool {
+        point.cmpge(self.min).all() && point.cmple(self.max).all()
+    }
+}
+
+pub struct Region {
+    pub bounds: AABB,
+    pub objects: Vec<MeshObjectInfo>,
+    handles: Vec<Handle<MeshObject>>,
+}
+
+impl Region {
+    pub fn new(bounds: AABB, objects: Vec<MeshObjectInfo>) -> Self {
+        Self {
+            bounds,
+            objects,
+            handles: Vec::new(),
+        }
+    }
+}
+
+pub struct StreamingManager {
+    pub regions: Vec<Region>,
+    pub active_regions: HashSet<usize>,
+}
+
+impl StreamingManager {
+    pub fn new() -> Self {
+        Self {
+            regions: Vec::new(),
+            active_regions: HashSet::new(),
+        }
+    }
+
+    pub fn register_region(&mut self, region: Region) -> usize {
+        let idx = self.regions.len();
+        self.regions.push(region);
+        idx
+    }
+
+    pub fn unregister_region(&mut self, index: usize, renderer: &mut RenderEngine) {
+        if index >= self.regions.len() {
+            return;
+        }
+
+        if self.active_regions.remove(&index) {
+            let region = &mut self.regions[index];
+            for handle in region.handles.drain(..) {
+                renderer.release_mesh_object(handle);
+            }
+        }
+
+        let last = self.regions.len() - 1;
+        self.regions.swap_remove(index);
+        if index != last {
+            if self.active_regions.remove(&last) {
+                self.active_regions.insert(index);
+            }
+        }
+    }
+
+    pub fn reset(&mut self, renderer: &mut RenderEngine) {
+        for idx in self.active_regions.drain() {
+            if let Some(region) = self.regions.get_mut(idx) {
+                for handle in region.handles.drain(..) {
+                    renderer.release_mesh_object(handle);
+                }
+            }
+        }
+    }
+
+    pub fn update(&mut self, player_pos: Vec3, db: &mut Database, renderer: &mut RenderEngine) {
+        let _ = db; // currently unused
+        let mut new_active = HashSet::new();
+        for (i, region) in self.regions.iter().enumerate() {
+            if region.bounds.contains(player_pos) {
+                new_active.insert(i);
+            }
+        }
+
+        // handle newly entered regions
+        for idx in new_active
+            .difference(&self.active_regions)
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if let Some(region) = self.regions.get_mut(idx) {
+                region.handles.clear();
+                for obj in &region.objects {
+                    let mesh_c = CString::new(obj.mesh).unwrap();
+                    let material_c = CString::new(obj.material).unwrap();
+                    let ffi_info = FFIMeshObjectInfo {
+                        mesh: mesh_c.as_ptr(),
+                        material: material_c.as_ptr(),
+                        transform: obj.transform,
+                    };
+                    match renderer.register_mesh_object(&ffi_info) {
+                        Ok(handle) => region.handles.push(handle),
+                        Err(e) => warn!("failed to register mesh object '{}': {}", obj.mesh, e),
+                    }
+                }
+            }
+        }
+
+        // handle exited regions
+        for idx in self
+            .active_regions
+            .difference(&new_active)
+            .cloned()
+            .collect::<Vec<_>>()
+        {
+            if let Some(region) = self.regions.get_mut(idx) {
+                for handle in region.handles.drain(..) {
+                    renderer.release_mesh_object(handle);
+                }
+            }
+        }
+
+        self.active_regions = new_active;
+    }
+}


### PR DESCRIPTION
## Summary
- add `streaming` module with `Region` and `StreamingManager`
- stream mesh objects based on player position
- expose helpers to register, unregister, and reset regions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68926db337b0832aa94f0ff10f83e9ce