### PR TITLE
Render set_scene logs failed resources

### DIFF
--- a/tests/scene_fail.rs
+++ b/tests/scene_fail.rs
@@ -1,0 +1,29 @@
+use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
+use std::fs;
+
+#[test]
+fn records_missing_resources() {
+    // Create temporary directory with minimal database.
+    let dir = tempfile::tempdir().unwrap();
+    let db_dir = dir.path().join("database");
+    fs::create_dir(&db_dir).unwrap();
+    fs::write(db_dir.join("db.json"), "{}").unwrap();
+
+    let mut render = RenderEngine::new(&RenderEngineInfo {
+        application_path: dir.path().to_str().unwrap().into(),
+        scene_info: None,
+        headless: true,
+        backend: RenderBackend::Canvas,
+    })
+    .unwrap();
+
+    let info = SceneInfo {
+        models: &["missing_model.gltf"],
+        images: &["missing.png"],
+    };
+    render.set_scene(&info).unwrap();
+
+    let errors = render.scene_load_errors();
+    assert_eq!(errors.models, vec!["missing_model.gltf".to_string()]);
+    assert_eq!(errors.images, vec!["missing.png".to_string()]);
+}


### PR DESCRIPTION
## Summary
- Track scene load failures and expose them to callers
- Keep rendering going by logging model/image load errors and returning `Ok(())`
- Test that missing resources are recorded instead of aborting

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68928c701ac4832aa08af9b9ce3b566a