### PR TITLE
Add asynchronous mesh loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ warm.intensity = 0.5;
 unsafe { meshi_gfx_set_directional_light_info(render, light, &warm) };
 ```
 
+## Resource database
+
+The rendering database now supports asynchronous model loading. Call
+`load_model_async(name)` to spawn a loader thread that parses the glTF file and
+uploads vertex and index data to GPU buffers. The returned `JoinHandle`
+resolves to a `MeshResource` that can be stored or rendered once complete.
+
+Loaded models can be removed with `unload_model(name)`, which drops their GPU
+buffers and frees associated memory. Additionally, `fetch_mesh` now accepts a
+`wait: bool` flag. When `wait` is `true` and the mesh is not yet resident, the
+database will load it synchronously before returning.
+

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -87,7 +87,7 @@ impl MeshObjectInfo {
             self.mesh, self.material
         );
 
-        let mesh = db.fetch_mesh(self.mesh)?;
+        let mesh = db.fetch_mesh(self.mesh, true)?;
         let material = db.fetch_material(self.material).map_err(|e| {
             warn!("failed to fetch material '{}': {}", self.material, e);
             e

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -283,7 +283,7 @@ impl RenderEngine {
                 );
                 let mesh = self
                     .database
-                    .fetch_mesh(info.mesh)
+                    .fetch_mesh(info.mesh, true)
                     .expect("failed to fetch mesh");
                 let material = self
                     .database
@@ -339,7 +339,7 @@ impl RenderEngine {
                 );
                 let mesh = self
                     .database
-                    .fetch_mesh(info.mesh)
+                    .fetch_mesh(info.mesh, true)
                     .expect("failed to fetch mesh");
                 let material = self
                     .database
@@ -497,7 +497,7 @@ impl RenderEngine {
                 );
                 let mesh = self
                     .database
-                    .fetch_mesh(info.mesh)
+                    .fetch_mesh(info.mesh, true)
                     .expect("failed to fetch mesh");
                 let material = self
                     .database


### PR DESCRIPTION
## Summary
- add threaded `load_model_async` helper and `unload_model` to purge geometry buffers
- extend `fetch_mesh` with optional waiting to synchronously load missing meshes
- document asynchronous loading in README and database module

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6892aa8e5f90832a9ad38e984b4936e6