### PR TITLE
guard invalid mesh handle when setting transform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,13 @@ pub extern "C" fn meshi_gfx_set_renderable_transform(
     if render.is_null() || transform.is_null() {
         return;
     }
+    if !h.valid() {
+        info!(
+            "Attempted to set transform for invalid mesh object handle (slot: {}, generation: {})",
+            h.slot, h.generation
+        );
+        return;
+    }
     unsafe { &mut *render }.set_mesh_object_transform(h, unsafe { &*transform });
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -4,9 +4,9 @@ use dashi::{
     utils::{Handle, Pool},
     *,
 };
-use image::RgbaImage;
 use database::{Database, Error as DatabaseError, MeshResource};
 use glam::{Mat4, Vec3, Vec4};
+use image::RgbaImage;
 use tracing::{info, warn};
 
 use crate::object::{
@@ -547,6 +547,15 @@ impl RenderEngine {
         handle: Handle<MeshObject>,
         transform: &glam::Mat4,
     ) {
+        if !handle.valid() {
+            info!(
+                "Attempted to set transform for invalid mesh object handle (slot: {}, generation: {})",
+                handle.slot,
+                handle.generation
+            );
+            return;
+        }
+
         match self.mesh_objects.get_mut_ref(handle) {
             Some(obj) => {
                 obj.transform = *transform;

--- a/tests/gfx_transform_invalid.rs
+++ b/tests/gfx_transform_invalid.rs
@@ -1,0 +1,33 @@
+use dashi::utils::Handle;
+use glam::Mat4;
+use meshi::render::RenderBackend;
+use meshi::*;
+use std::ffi::CString;
+
+#[test]
+fn set_transform_with_invalid_handle_does_nothing() {
+    let name = CString::new("test").unwrap();
+    let loc = CString::new(".").unwrap();
+    let info = MeshiEngineInfo {
+        application_name: name.as_ptr(),
+        application_location: loc.as_ptr(),
+        headless: 1,
+        render_backend: RenderBackend::Canvas,
+    };
+    let engine = unsafe { meshi_make_engine(&info) };
+    assert!(!engine.is_null());
+    let render = unsafe { meshi_get_graphics_system(engine) };
+    assert!(!render.is_null());
+
+    let invalid = Handle::default();
+    let transform = Mat4::IDENTITY;
+    unsafe { meshi_gfx_set_renderable_transform(render, invalid, &transform) };
+
+    let cube = unsafe { meshi_gfx_create_cube(render) };
+    unsafe { meshi_gfx_set_renderable_transform(render, cube, &transform) };
+
+    unsafe {
+        meshi_gfx_release_mesh_object(render, &cube);
+        meshi_destroy_engine(engine);
+    }
+}


### PR DESCRIPTION
## Summary
- check mesh handle validity before updating transform in RenderEngine
- log and skip transform call for invalid handles via `meshi_gfx_set_renderable_transform`
- test setting transform with an invalid handle

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689652cc1d44832a87a6f28bc3314bbb