### PR TITLE
Support glTF mesh selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ buffers and frees associated memory. Additionally, `fetch_mesh` now accepts a
 `wait: bool` flag. When `wait` is `true` and the mesh is not yet resident, the
 database will load it synchronously before returning.
 
+Model paths may include a `#` selector to reference a specific mesh or
+primitive inside a glTF file. Use `file.gltf#mesh_name` or
+`file.gltf#1/0` to select a mesh by name or index and optionally a
+primitive index. When no selector is provided the database loads the first
+primitive of the first mesh.
+

--- a/src/render/database/json.rs
+++ b/src/render/database/json.rs
@@ -26,7 +26,11 @@ pub struct Materials {
 
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct GeometryEntry {
+    /// Name used to reference this mesh.
     pub name: String,
+    /// Path to a glTF file relative to the database root. A `#mesh` or
+    /// `#mesh/primitive` suffix may be appended to target a specific mesh and
+    /// primitive within the file.
     pub path: String,
 }
 

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -497,33 +497,29 @@ mod tests {
 
     #[test]
     fn load_model_sync_supports_selectors() {
-        let dir = tempdir().unwrap();
-        let model = write_triangle_gltf(dir.path());
+        let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data");
+        let base = base.to_str().unwrap();
         let mut ctx = dashi::Context::headless(&Default::default()).unwrap();
 
-        // Loading by mesh name succeeds.
-        Database::load_model_sync(
-            dir.path().to_str().unwrap(),
-            &mut ctx,
-            &format!("{model}#mesh0"),
-        )
-        .expect("failed to load mesh by name");
+        // Loading by mesh name defaults to the first primitive.
+        Database::load_model_sync(base, &mut ctx, "selector.gltf#Mesh1")
+            .expect("failed to load mesh by name");
+
+        // Loading by mesh name and primitive index succeeds.
+        Database::load_model_sync(base, &mut ctx, "selector.gltf#Mesh1/1")
+            .expect("failed to load primitive by name");
+
+        // Loading by mesh index and primitive index succeeds.
+        Database::load_model_sync(base, &mut ctx, "selector.gltf#1/1")
+            .expect("failed to load primitive by index");
 
         // Invalid mesh index should error.
-        assert!(Database::load_model_sync(
-            dir.path().to_str().unwrap(),
-            &mut ctx,
-            &format!("{model}#1"),
-        )
-        .is_err());
+        assert!(Database::load_model_sync(base, &mut ctx, "selector.gltf#2").is_err());
 
         // Invalid primitive index should error.
-        assert!(Database::load_model_sync(
-            dir.path().to_str().unwrap(),
-            &mut ctx,
-            &format!("{model}#/1"),
-        )
-        .is_err());
+        assert!(
+            Database::load_model_sync(base, &mut ctx, "selector.gltf#Mesh1/5").is_err()
+        );
 
         ctx.destroy();
     }

--- a/tests/data/selector.gltf
+++ b/tests/data/selector.gltf
@@ -1,0 +1,37 @@
+{
+  "asset": { "version": "2.0" },
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAABAAIAAAACAAEA",
+      "byteLength": 48
+    }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 36 },
+    { "buffer": 0, "byteOffset": 36, "byteLength": 6 },
+    { "buffer": 0, "byteOffset": 42, "byteLength": 6 }
+  ],
+  "accessors": [
+    { "bufferView": 0, "componentType": 5126, "count": 3, "type": "VEC3", "min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 0.0] },
+    { "bufferView": 1, "componentType": 5123, "count": 3, "type": "SCALAR" },
+    { "bufferView": 2, "componentType": 5123, "count": 3, "type": "SCALAR" }
+  ],
+  "meshes": [
+    {
+      "name": "Mesh0",
+      "primitives": [
+        { "attributes": { "POSITION": 0 }, "indices": 1 }
+      ]
+    },
+    {
+      "name": "Mesh1",
+      "primitives": [
+        { "attributes": { "POSITION": 0 }, "indices": 1 },
+        { "attributes": { "POSITION": 0 }, "indices": 2 }
+      ]
+    }
+  ],
+  "nodes": [ { "mesh": 0 }, { "mesh": 1 } ],
+  "scenes": [ { "nodes": [0, 1] } ],
+  "scene": 0
+}


### PR DESCRIPTION
## Summary
- allow `load_model_sync` to parse `file.gltf#mesh[/primitive]` selectors
- document new mesh/primitive selector format in database schema and README
- add tests for selector loading and update geometry resource init

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689652d3c928832a8c551cf5ea4b424b