### PR TITLE
Handle CString conversion failures

### DIFF
--- a/examples/audio_playback.rs
+++ b/examples/audio_playback.rs
@@ -8,18 +8,12 @@ fn system_sound_path() -> Option<&'static str> {
             "/usr/share/sounds/alsa/Front_Center.wav",
             "/usr/share/sounds/freedesktop/stereo/bell.oga",
         ];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(target_os = "macos")]
     {
         const CANDIDATES: [&str; 1] = ["/System/Library/Sounds/Glass.aiff"];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(target_os = "windows")]
     {
@@ -27,10 +21,7 @@ fn system_sound_path() -> Option<&'static str> {
             "C:\\Windows\\Media\\notify.wav",
             "C:\\Windows\\Media\\tada.wav",
         ];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {

--- a/examples/ffi_init.rs
+++ b/examples/ffi_init.rs
@@ -7,8 +7,8 @@ use meshi::*;
 use std::ffi::CString;
 
 fn main() {
-    let app = CString::new("Example").unwrap();
-    let loc = CString::new(".").unwrap();
+    let app = CString::new("Example").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let engine = unsafe { meshi_make_engine_headless(app.as_ptr(), loc.as_ptr()) };
     let render = unsafe { meshi_get_graphics_system(engine) };
     let info = CubePrimitiveInfo { size: 2.0 };

--- a/examples/ffi_physics.rs
+++ b/examples/ffi_physics.rs
@@ -4,8 +4,8 @@ use meshi::{render::RenderBackend, *};
 use std::ffi::CString;
 
 fn main() {
-    let app = CString::new("Example").unwrap();
-    let loc = CString::new(".").unwrap();
+    let app = CString::new("Example").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: app.as_ptr(),
         application_location: loc.as_ptr(),

--- a/examples/simple_render.rs
+++ b/examples/simple_render.rs
@@ -28,8 +28,8 @@ fn main() {
     render.set_scene(&scene).expect("scene loading failed");
 
     // Register the loaded mesh for drawing using its associated texture.
-    let mesh = CString::new("model.gltf").unwrap();
-    let tex = CString::new("albedo.png").unwrap();
+    let mesh = CString::new("model.gltf").unwrap_or_default();
+    let tex = CString::new("albedo.png").unwrap_or_default();
     let info = FFIMeshObjectInfo {
         mesh: mesh.as_ptr(),
         material: tex.as_ptr(),

--- a/src/render/config.rs
+++ b/src/render/config.rs
@@ -1,6 +1,5 @@
-
 #[derive(Default)]
 pub struct RenderEngineConfig {
     pub scene_cfg_path: Option<String>,
-    pub database_path: Option<String>
+    pub database_path: Option<String>,
 }

--- a/src/render/database/font.rs
+++ b/src/render/database/font.rs
@@ -51,7 +51,7 @@ impl TTFont {
                     let px = i % metrics.width;
                     let py = i / metrics.width;
                     let x = (cursor_x as usize) + px;
-                    let y = (cursor_y  as i32) as usize + py;
+                    let y = (cursor_y as i32) as usize + py;
 
                     bitmap[y * width as usize + x] = pixel;
                 }

--- a/src/render/database/mod.rs
+++ b/src/render/database/mod.rs
@@ -517,9 +517,7 @@ mod tests {
         assert!(Database::load_model_sync(base, &mut ctx, "selector.gltf#2").is_err());
 
         // Invalid primitive index should error.
-        assert!(
-            Database::load_model_sync(base, &mut ctx, "selector.gltf#Mesh1/5").is_err()
-        );
+        assert!(Database::load_model_sync(base, &mut ctx, "selector.gltf#Mesh1/5").is_err());
 
         ctx.destroy();
     }

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -34,8 +34,14 @@ impl Region {
         let mut mesh_cstrings = Vec::with_capacity(objects.len());
         let mut material_cstrings = Vec::with_capacity(objects.len());
         for obj in &objects {
-            mesh_cstrings.push(CString::new(obj.mesh).unwrap());
-            material_cstrings.push(CString::new(obj.material).unwrap());
+            mesh_cstrings.push(CString::new(obj.mesh).unwrap_or_else(|e| {
+                warn!("invalid mesh name '{}': {}", obj.mesh, e);
+                CString::default()
+            }));
+            material_cstrings.push(CString::new(obj.material).unwrap_or_else(|e| {
+                warn!("invalid material name '{}': {}", obj.material, e);
+                CString::default()
+            }));
         }
         Self {
             bounds,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,1 @@
 pub mod timer;
-
-

--- a/tests/audio_playback.rs
+++ b/tests/audio_playback.rs
@@ -9,18 +9,12 @@ fn system_sound_path() -> Option<&'static str> {
             "/usr/share/sounds/alsa/Front_Center.wav",
             "/usr/share/sounds/freedesktop/stereo/bell.oga",
         ];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(target_os = "macos")]
     {
         const CANDIDATES: [&str; 1] = ["/System/Library/Sounds/Glass.aiff"];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(target_os = "windows")]
     {
@@ -28,10 +22,7 @@ fn system_sound_path() -> Option<&'static str> {
             "C:\\Windows\\Media\\notify.wav",
             "C:\\Windows\\Media\\tada.wav",
         ];
-        CANDIDATES
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .copied()
+        CANDIDATES.iter().find(|p| Path::new(p).exists()).copied()
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {

--- a/tests/audio_state.rs
+++ b/tests/audio_state.rs
@@ -1,7 +1,5 @@
 use meshi::audio::{AudioEngine, AudioEngineInfo, PlaybackState};
-use meshi::{
-    meshi_audio_get_state, meshi_audio_pause, meshi_audio_play, meshi_audio_stop,
-};
+use meshi::{meshi_audio_get_state, meshi_audio_pause, meshi_audio_play, meshi_audio_stop};
 use serial_test::serial;
 
 #[test]

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -10,8 +10,8 @@ use meshi::*;
 use std::ffi::CString;
 
 fn main() {
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -125,8 +125,8 @@ fn main() {
         return;
     }
 
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/gfx_create_renderable_err.rs
+++ b/tests/gfx_create_renderable_err.rs
@@ -1,12 +1,12 @@
 use dashi::utils::Handle;
 use glam::Mat4;
-use meshi::{*, render::RenderBackend};
+use meshi::{render::RenderBackend, *};
 use std::ffi::CString;
 
 #[test]
 fn invalid_info_returns_default_handle() {
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/gfx_release.rs
+++ b/tests/gfx_release.rs
@@ -3,8 +3,8 @@ use meshi::*;
 use std::ffi::CString;
 
 fn main() {
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/gfx_transform_invalid.rs
+++ b/tests/gfx_transform_invalid.rs
@@ -6,8 +6,8 @@ use std::ffi::CString;
 
 #[test]
 fn set_transform_with_invalid_handle_does_nothing() {
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/graph_backend.rs
+++ b/tests/graph_backend.rs
@@ -10,7 +10,11 @@ fn render_triangle(backend: RenderBackend) -> RgbaImage {
     let db_dir = base.join("database");
     std::fs::create_dir(&db_dir).unwrap();
     std::fs::write(db_dir.join("db.json"), "{}".as_bytes()).unwrap();
-    std::fs::write(base.join("koji.json"), "{\"nodes\":[],\"edges\":[]}".as_bytes()).unwrap();
+    std::fs::write(
+        base.join("koji.json"),
+        "{\"nodes\":[],\"edges\":[]}".as_bytes(),
+    )
+    .unwrap();
 
     let mut render = RenderEngine::new(&RenderEngineInfo {
         application_path: base.to_str().unwrap().into(),
@@ -20,7 +24,10 @@ fn render_triangle(backend: RenderBackend) -> RgbaImage {
     })
     .expect("renderer init");
 
-    let scene_info = SceneInfo { models: &[], images: &[] };
+    let scene_info = SceneInfo {
+        models: &[],
+        images: &[],
+    };
     render.set_scene(&scene_info).expect("scene load");
 
     render.create_triangle();
@@ -34,4 +41,3 @@ fn graph_backend_matches_canvas() {
     let graph = render_triangle(RenderBackend::Graph);
     assert_eq!(canvas.as_raw(), graph.as_raw());
 }
-

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -5,8 +5,8 @@ use meshi::*;
 use std::ffi::CString;
 
 fn main() {
-    let name = CString::new("test").unwrap();
-    let loc = CString::new(".").unwrap();
+    let name = CString::new("test").unwrap_or_default();
+    let loc = CString::new(".").unwrap_or_default();
     let info = MeshiEngineInfo {
         application_name: name.as_ptr(),
         application_location: loc.as_ptr(),

--- a/tests/render_output.rs
+++ b/tests/render_output.rs
@@ -33,7 +33,11 @@ fn run_backend(backend: RenderBackend) {
     let db_dir = base.join("database");
     std::fs::create_dir(&db_dir).unwrap();
     std::fs::write(db_dir.join("db.json"), "{}".as_bytes()).unwrap();
-    std::fs::write(base.join("koji.json"), "{\"nodes\":[],\"edges\":[]}".as_bytes()).unwrap();
+    std::fs::write(
+        base.join("koji.json"),
+        "{\"nodes\":[],\"edges\":[]}".as_bytes(),
+    )
+    .unwrap();
 
     let mut render = RenderEngine::new(&RenderEngineInfo {
         application_path: base.to_str().unwrap().into(),
@@ -44,9 +48,7 @@ fn run_backend(backend: RenderBackend) {
     .expect("renderer init");
 
     render.create_triangle();
-    let img = render
-        .render_to_image(EXTENT)
-        .expect("render to image");
+    let img = render.render_to_image(EXTENT).expect("render to image");
     let expected = expected_triangle(EXTENT[0], EXTENT[1]);
     assert_eq!(img.as_raw(), expected.as_raw());
 }


### PR DESCRIPTION
## Summary
- replace `CString::new(...).unwrap()` calls across examples and tests with `unwrap_or_default`
- stream setup now logs and defaults invalid mesh or material names instead of panicking

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689662372a38832abd3575e594f32a44