### PR TITLE
Expose optional canvas extent for canvas renderer

### DIFF
--- a/examples/ffi_physics.rs
+++ b/examples/ffi_physics.rs
@@ -11,6 +11,7 @@ fn main() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     let physics = unsafe { meshi_get_physics_system(engine) };

--- a/examples/simple_render.rs
+++ b/examples/simple_render.rs
@@ -17,6 +17,7 @@ fn main() {
         scene_info: None,
         headless: false,
         backend,
+        canvas_extent: None,
     })
     .expect("failed to initialize renderer");
 

--- a/include/meshi/meshi_types.h
+++ b/include/meshi/meshi_types.h
@@ -46,6 +46,7 @@ struct MeshiEngineInfo {
     const char* application_location;
     std::int32_t headless;
     MeshiRenderBackend render_backend;
+    const std::uint32_t* canvas_extent;
 };
 
 struct MeshiFFIMeshObjectInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ pub struct MeshiEngineInfo {
     pub headless: i32,
     /// Backend to use for rendering.
     pub render_backend: RenderBackend,
+    /// Optional extent to override the default canvas size.
+    pub canvas_extent: *const u32,
 }
 
 /// Primary engine instance returned by [`meshi_make_engine`].
@@ -83,6 +85,14 @@ impl MeshiEngine {
                 scene_info: None,
                 headless: info.headless != 0,
                 backend: info.render_backend,
+                canvas_extent: if info.canvas_extent.is_null() {
+                    None
+                } else {
+                    Some(unsafe { [
+                        *info.canvas_extent,
+                        *info.canvas_extent.add(1),
+                    ] })
+                },
             })
             .expect("failed to initialize render engine"),
             physics: Box::new(PhysicsSimulation::new(&Default::default())),
@@ -150,6 +160,7 @@ pub extern "C" fn meshi_make_engine_headless(
         application_location,
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     meshi_make_engine(&info)
 }

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -1,18 +1,17 @@
 use dashi::{utils::Pool, Attachment, DrawIndexed, Format, RenderPassBegin, SubmitInfo};
 use image::{Rgba, RgbaImage};
 use koji::{Canvas, CanvasBuilder};
-use winit::dpi::PhysicalSize;
-
 use super::RenderError;
 use crate::object::MeshObject;
 
 pub struct CanvasRenderer {
     canvas: Option<Canvas>,
+    extent: Option<[u32; 2]>,
 }
 
 impl CanvasRenderer {
-    pub fn new() -> Self {
-        Self { canvas: None }
+    pub fn new(extent: Option<[u32; 2]>) -> Self {
+        Self { canvas: None, extent }
     }
 
     pub fn render(
@@ -22,10 +21,14 @@ impl CanvasRenderer {
         mesh_objects: &Pool<MeshObject>,
     ) -> Result<(), RenderError> {
         if self.canvas.is_none() {
-            println!("aaa");
-            let p = display.winit_window().inner_size();
+            let [width, height] = if let Some(extent) = self.extent {
+                extent
+            } else {
+                let p = display.winit_window().inner_size();
+                [p.width, p.height]
+            };
             let canvas = CanvasBuilder::new()
-                .extent([p.width, p.height])
+                .extent([width, height])
                 .color_attachment("color", Format::RGBA8)
                 .build(ctx)?;
             self.canvas = Some(canvas);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -131,6 +131,7 @@ pub struct RenderEngineInfo<'a> {
     pub scene_info: Option<SceneInfo<'a>>,
     pub headless: bool,
     pub backend: RenderBackend,
+    pub canvas_extent: Option<[u32; 2]>,
 }
 
 struct EventCallbackInfo {
@@ -177,7 +178,7 @@ impl RenderEngine {
         let backend = match info.backend {
             RenderBackend::Canvas => {
                 info!("Using canvas backend");
-                Backend::Canvas(canvas::CanvasRenderer::new())
+                Backend::Canvas(canvas::CanvasRenderer::new(info.canvas_extent))
             }
             RenderBackend::Graph => {
                 info!("Using graph backend");

--- a/tests/directional_light_render.rs
+++ b/tests/directional_light_render.rs
@@ -45,6 +45,7 @@ fn run_backend(backend: RenderBackend) {
         scene_info: None,
         headless: true,
         backend,
+        canvas_extent: None,
     })
     .expect("renderer init");
 

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -17,6 +17,7 @@ fn main() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     assert!(!engine.is_null());

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -132,6 +132,7 @@ fn main() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     let counter = Arc::new(AtomicUsize::new(0));

--- a/tests/gfx_create_renderable_err.rs
+++ b/tests/gfx_create_renderable_err.rs
@@ -12,6 +12,7 @@ fn invalid_info_returns_default_handle() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     assert!(!engine.is_null());

--- a/tests/gfx_release.rs
+++ b/tests/gfx_release.rs
@@ -10,6 +10,7 @@ fn main() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     let render = unsafe { meshi_get_graphics_system(engine) };

--- a/tests/gfx_transform_invalid.rs
+++ b/tests/gfx_transform_invalid.rs
@@ -13,6 +13,7 @@ fn set_transform_with_invalid_handle_does_nothing() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
     assert!(!engine.is_null());

--- a/tests/graph_backend.rs
+++ b/tests/graph_backend.rs
@@ -17,6 +17,7 @@ fn render_triangle(backend: RenderBackend) -> RgbaImage {
         scene_info: None,
         headless: true,
         backend,
+        canvas_extent: None,
     })
     .expect("renderer init");
 

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -12,6 +12,7 @@ fn main() {
         application_location: loc.as_ptr(),
         headless: 1,
         render_backend: RenderBackend::Canvas,
+        canvas_extent: std::ptr::null(),
     };
     let engine = unsafe { meshi_make_engine(&info) };
 

--- a/tests/render_output.rs
+++ b/tests/render_output.rs
@@ -40,6 +40,7 @@ fn run_backend(backend: RenderBackend) {
         scene_info: None,
         headless: true,
         backend,
+        canvas_extent: None,
     })
     .expect("renderer init");
 

--- a/tests/render_primitives.rs
+++ b/tests/render_primitives.rs
@@ -58,6 +58,7 @@ where
         scene_info: None,
         headless: true,
         backend,
+        canvas_extent: None,
     })
     .expect("renderer init");
 

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -50,6 +50,7 @@ fn main() {
         scene_info: None,
         headless: true,
         backend: RenderBackend::Canvas,
+        canvas_extent: None,
     })
     .expect("failed to initialize renderer");
 

--- a/tests/scene_fail.rs
+++ b/tests/scene_fail.rs
@@ -14,6 +14,7 @@ fn records_missing_resources() {
         scene_info: None,
         headless: true,
         backend: RenderBackend::Canvas,
+        canvas_extent: None,
     })
     .unwrap();
 

--- a/tests/scene_render.rs
+++ b/tests/scene_render.rs
@@ -39,8 +39,9 @@ fn run_backend(backend: RenderBackend) {
     let mut render = RenderEngine::new(&RenderEngineInfo {
         application_path: base.to_str().unwrap().into(),
         scene_info: None,
-        headless: true,
+       headless: true,
         backend,
+        canvas_extent: None,
     })
     .expect("renderer init");
 


### PR DESCRIPTION
## Summary
- allow specifying an optional canvas extent in `RenderEngineInfo`
- forward the extent through FFI and `MeshiEngineInfo`
- use the custom extent in `CanvasRenderer` when creating the canvas

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68969dea3e1c832aaee8537f06903c03