### PR TITLE
Integrate Koji renderer and bind graphics pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "glam",
  "gltf",
  "image 0.24.9",
+ "inline-spirv",
  "koji",
  "rayon",
  "rodio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ base64 = "0.22.1"
 winit = "0.26"
 rayon = "1.10"
 rodio = { version = "0.17" }
+inline-spirv = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/render/canvas.rs
+++ b/src/render/canvas.rs
@@ -1,17 +1,26 @@
-use dashi::{utils::Pool, Attachment, DrawIndexed, Format, RenderPassBegin, SubmitInfo};
-use image::{Rgba, RgbaImage};
-use koji::{Canvas, CanvasBuilder};
 use super::RenderError;
 use crate::object::MeshObject;
+use dashi::{utils::Pool, Attachment, DrawBegin, DrawIndexed, Format, SubmitInfo};
+use image::{Rgba, RgbaImage};
+use inline_spirv::inline_spirv;
+use koji::renderer::Renderer;
+use koji::{material::PSO, Canvas, CanvasBuilder, PipelineBuilder, RenderPassBuilder};
 
 pub struct CanvasRenderer {
     canvas: Option<Canvas>,
     extent: Option<[u32; 2]>,
+    renderer: Option<Renderer>,
+    pipeline: Option<PSO>,
 }
 
 impl CanvasRenderer {
     pub fn new(extent: Option<[u32; 2]>) -> Self {
-        Self { canvas: None, extent }
+        Self {
+            canvas: None,
+            extent,
+            renderer: None,
+            pipeline: None,
+        }
     }
 
     pub fn render(
@@ -27,10 +36,45 @@ impl CanvasRenderer {
                 let p = display.winit_window().inner_size();
                 [p.width, p.height]
             };
+
+            // Create renderer and simple pipeline
+            let renderer = Renderer::with_render_pass(
+                width,
+                height,
+                ctx,
+                RenderPassBuilder::new()
+                    .color_attachment("color", Format::RGBA8)
+                    .subpass("main", ["color"], &[] as &[&str]),
+            )?;
+
             let canvas = CanvasBuilder::new()
                 .extent([width, height])
                 .color_attachment("color", Format::RGBA8)
                 .build(ctx)?;
+
+            let vert = inline_spirv!(
+                r#"#version 450
+                layout(location=0) in vec4 position;
+                void main() { gl_Position = position; }
+                "#,
+                vert
+            );
+            let frag = inline_spirv!(
+                r#"#version 450
+                layout(location=0) out vec4 color;
+                void main() { color = vec4(1.0,1.0,1.0,1.0); }
+                "#,
+                frag
+            );
+
+            let pso = PipelineBuilder::new(ctx, "canvas_pso")
+                .vertex_shader(vert)
+                .fragment_shader(frag)
+                .render_pass((canvas.render_pass(), 0))
+                .build();
+
+            self.pipeline = Some(pso);
+            self.renderer = Some(renderer);
             self.canvas = Some(canvas);
         }
 
@@ -48,11 +92,13 @@ impl CanvasRenderer {
         let mut cmd = ctx.begin_command_list(&Default::default())?;
 
         let result: Result<(), RenderError> = (|| {
-            cmd.begin_render_pass(&RenderPassBegin {
-                render_pass: canvas.render_pass(),
+            let pso = self.pipeline.as_ref().unwrap();
+            let draw_begin = DrawBegin {
                 viewport: Default::default(),
+                pipeline: pso.pipeline,
                 attachments: &attachments,
-            })?;
+            };
+            cmd.begin_drawing(&draw_begin)?;
 
             mesh_objects.for_each_occupied(|obj| {
                 cmd.draw_indexed(DrawIndexed {
@@ -63,7 +109,6 @@ impl CanvasRenderer {
                 });
             });
 
-            // ensure render pass closed
             cmd.end_drawing()?;
 
             let fence = ctx.submit(


### PR DESCRIPTION
## Summary
- Add inline-spirv dependency for embedded shader compilation
- Create Koji renderer and graphics pipeline in CanvasRenderer and GraphRenderer
- Bind pipeline via DrawBegin before issuing indexed draws

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6896a6d22f2c832ab3ade5aada9eb5be