### PR TITLE
Unpin Koji dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "koji"
 version = "0.1.0"
-source = "git+https://github.com/JordanHendl/koji?branch=main#9caeab7fda99266ce7897710bfa7e7766fd5bafd"
+source = "git+https://github.com/JordanHendl/koji?branch=main#22599e170104d332d7c244097d68838e1a152894"
 dependencies = [
  "bytemuck",
  "dashi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ fontdue = "0.9.2"
 #dashi = {path = "/wksp/git/dashi", features = ["dashi-serde"]}
 #miso = {path = "/wksp/git/miso"}
 dashi = {version = "0.1.0", git = "https://github.com/JordanHendl/dashi", features = ["dashi-serde"]}
-koji = {version = "0.1.0", git = "https://github.com/JordanHendl/koji", branch = "main"}
+koji = {git = "https://github.com/JordanHendl/koji", branch = "main"}
 gltf = "1.4.1"  # For reading glTF files
 unzip3 = "1.0.0"
 base64 = "0.22.1"


### PR DESCRIPTION
## Summary
- rely on Koji's `main` branch without explicit version pin
- update Cargo.lock to latest Koji commit

## Testing
- `cargo update -p koji`
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_6896dee301b8832aadbe1ec39333db05