### PR TITLE
Register GPU resources for assets and update pipeline creation

### DIFF
--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -88,14 +88,14 @@ impl MeshObjectInfo {
         );
 
         let mesh = db.fetch_mesh(self.mesh, true)?;
-        let material = match db.fetch_material(self.material) {
+        let material = match db.fetch_material(self.material, None) {
             Ok(mat) => mat,
             Err(e) => {
                 warn!(
                     "Failed to fetch material '{}': {}; falling back to default",
                     self.material, e
                 );
-                db.fetch_material("DEFAULT")?
+                db.fetch_material("DEFAULT", None)?
             }
         };
 

--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -70,11 +70,16 @@ impl GraphRenderer {
                 "#,
                 frag
             );
+            let (pass, _) = renderer
+                .graph()
+                .render_pass_for_output("swapchain")
+                .expect("missing swapchain output");
             let mut pso = PipelineBuilder::new(ctx, "graph_pso")
                 .vertex_shader(vert)
                 .fragment_shader(frag)
-                .render_pass(renderer.graph().output("swapchain"))
-                .build();
+                .render_pass((pass, 0))
+                .build_with_resources(renderer.resources())
+                .unwrap();
             let bgr = pso.create_bind_groups(renderer.resources()).unwrap();
             renderer.register_material_pipeline("graph_pso", pso, bgr);
             self.renderer = Some(renderer);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -346,7 +346,7 @@ impl RenderEngine {
                     .expect("failed to fetch mesh");
                 let material = self
                     .database
-                    .fetch_material("DEFAULT")
+                    .fetch_material("DEFAULT", None)
                     .expect("failed to fetch default material");
                 MeshObject {
                     targets: vec![MeshTarget {
@@ -372,7 +372,7 @@ impl RenderEngine {
         });
         let material = self
             .database
-            .fetch_material("DEFAULT")
+            .fetch_material("DEFAULT", None)
             .expect("failed to fetch default material");
         let target = MeshTarget {
             mesh: mesh.clone(),
@@ -408,7 +408,7 @@ impl RenderEngine {
                     .expect("failed to fetch mesh");
                 let material = self
                     .database
-                    .fetch_material("DEFAULT")
+                    .fetch_material("DEFAULT", None)
                     .expect("failed to fetch default material");
                 MeshObject {
                     targets: vec![MeshTarget {
@@ -434,7 +434,7 @@ impl RenderEngine {
         });
         let material = self
             .database
-            .fetch_material("DEFAULT")
+            .fetch_material("DEFAULT", None)
             .expect("failed to fetch default material");
         let target = MeshTarget {
             mesh: mesh.clone(),
@@ -474,7 +474,7 @@ impl RenderEngine {
         });
         let material = self
             .database
-            .fetch_material("DEFAULT")
+            .fetch_material("DEFAULT", None)
             .expect("failed to fetch default material");
         let target = MeshTarget {
             mesh: mesh.clone(),
@@ -514,7 +514,7 @@ impl RenderEngine {
         });
         let material = self
             .database
-            .fetch_material("DEFAULT")
+            .fetch_material("DEFAULT", None)
             .expect("failed to fetch default material");
         let target = MeshTarget {
             mesh: mesh.clone(),
@@ -554,7 +554,7 @@ impl RenderEngine {
         });
         let material = self
             .database
-            .fetch_material("DEFAULT")
+            .fetch_material("DEFAULT", None)
             .expect("failed to fetch default material");
         let target = MeshTarget {
             mesh: mesh.clone(),
@@ -590,7 +590,7 @@ impl RenderEngine {
                     .expect("failed to fetch mesh");
                 let material = self
                     .database
-                    .fetch_material("DEFAULT")
+                    .fetch_material("DEFAULT", None)
                     .expect("failed to fetch default material");
                 MeshObject {
                     targets: vec![MeshTarget {
@@ -763,7 +763,7 @@ impl RenderEngine {
         }
 
         for i in info.images {
-            if let Err(e) = self.database.load_image(i) {
+            if let Err(e) = self.database.load_image(i, None) {
                 warn!("Failed to load image {}: {}", i, e);
                 self.scene_load_errors.images.push((*i).to_string());
             }


### PR DESCRIPTION
## Summary
- register textures and materials with renderer resources when loaded
- adapt pipeline creation to use `build_with_resources` and bind group creation
- update callers for new database APIs

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689778111b04832ab33aecb464922aa2