### PR TITLE
Refactor primitive mesh generation for CPU data

### DIFF
--- a/src/render/database/geometry.rs
+++ b/src/render/database/geometry.rs
@@ -4,57 +4,43 @@ use std::path::Path;
 use gltf::Gltf;
 
 use super::{geometry_primitives, MeshResource};
-use dashi::Context;
-use tracing::warn;
 
 /// Load the default set of mesh primitives into a map keyed by their names.
 ///
 /// The database uses this during initialization so tests can rely on a small
 /// library of meshes (triangle, cube and sphere) without hitting the file
 /// system.
-pub fn load_primitives(ctx: &mut Context) -> HashMap<String, MeshResource> {
+pub fn load_primitives() -> HashMap<String, MeshResource> {
     let mut geometry = HashMap::new();
+    let tri = geometry_primitives::make_triangle(&Default::default());
     geometry.insert(
         "MESHI_TRIANGLE".to_string(),
-        geometry_primitives::make_triangle(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate triangle primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("TRIANGLE", tri),
     );
+    let cube = geometry_primitives::make_cube(&Default::default());
     geometry.insert(
         "MESHI_CUBE".to_string(),
-        geometry_primitives::make_cube(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate cube primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("CUBE", cube),
     );
+    let sphere = geometry_primitives::make_sphere(&Default::default());
     geometry.insert(
         "MESHI_SPHERE".to_string(),
-        geometry_primitives::make_sphere(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate sphere primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("SPHERE", sphere),
     );
+    let cyl = geometry_primitives::make_cylinder(&Default::default());
     geometry.insert(
         "MESHI_CYLINDER".to_string(),
-        geometry_primitives::make_cylinder(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate cylinder primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("CYLINDER", cyl),
     );
+    let plane = geometry_primitives::make_plane(&Default::default());
     geometry.insert(
         "MESHI_PLANE".to_string(),
-        geometry_primitives::make_plane(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate plane primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("PLANE", plane),
     );
+    let cone = geometry_primitives::make_cone(&Default::default());
     geometry.insert(
         "MESHI_CONE".to_string(),
-        geometry_primitives::make_cone(&Default::default(), ctx).unwrap_or_else(|e| {
-            warn!("failed to allocate cone primitive: {:?}", e);
-            MeshResource::default()
-        }),
+        MeshResource::from_primitive("CONE", cone),
     );
     geometry
 }

--- a/src/render/database/geometry_primitives.rs
+++ b/src/render/database/geometry_primitives.rs
@@ -1,4 +1,4 @@
-use crate::render::database::{MeshResource, Vertex};
+use crate::render::database::{PrimitiveMesh, Vertex};
 use glam::{IVec4, Vec2, Vec4};
 use tracing::info;
 
@@ -13,10 +13,7 @@ impl Default for CubePrimitiveInfo {
     }
 }
 
-pub fn make_cube(
-    info: &CubePrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_cube(info: &CubePrimitiveInfo) -> PrimitiveMesh {
     let size = info.size;
 
     let cvertices: [Vertex; 8] = [
@@ -102,15 +99,7 @@ pub fn make_cube(
     let indices = INDICES.to_vec();
 
     info!("Registering Default Cube Mesh..");
-    Ok(MeshResource {
-        name: "CUBE".to_string(),
-        vertices,
-        num_vertices: cvertices.len(),
-        indices,
-        num_indices: INDICES.len(),
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }
 
 #[repr(C)]
@@ -124,10 +113,7 @@ impl Default for TrianglePrimitiveInfo {
     }
 }
 
-pub fn make_triangle(
-    info: &TrianglePrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_triangle(info: &TrianglePrimitiveInfo) -> PrimitiveMesh {
     let size = info.size;
     let tvertices: [Vertex; 3] = [
         Vertex {
@@ -162,15 +148,7 @@ pub fn make_triangle(
     let indices = INDICES.to_vec();
 
     info!("Registering Default Triangle Mesh..");
-    Ok(MeshResource {
-        name: "TRIANGLE".to_string(),
-        vertices,
-        num_vertices: tvertices.len(),
-        indices,
-        num_indices: INDICES.len(),
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }
 
 #[repr(C)]
@@ -190,10 +168,7 @@ impl Default for SpherePrimitiveInfo {
     }
 }
 
-pub fn make_sphere(
-    info: &SpherePrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_sphere(info: &SpherePrimitiveInfo) -> PrimitiveMesh {
     let SpherePrimitiveInfo {
         radius,
         segments,
@@ -237,18 +212,8 @@ pub fn make_sphere(
         }
     }
 
-    let num_vertices = vertices.len();
-    let num_indices = indices.len();
     info!("Registering Default Sphere Mesh..");
-    Ok(MeshResource {
-        name: "SPHERE".to_string(),
-        vertices,
-        num_vertices,
-        indices,
-        num_indices,
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }
 
 #[repr(C)]
@@ -268,10 +233,7 @@ impl Default for CylinderPrimitiveInfo {
     }
 }
 
-pub fn make_cylinder(
-    info: &CylinderPrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_cylinder(info: &CylinderPrimitiveInfo) -> PrimitiveMesh {
     let CylinderPrimitiveInfo {
         radius,
         height,
@@ -382,18 +344,8 @@ pub fn make_cylinder(
         indices.push(current);
     }
 
-    let num_vertices = vertices.len();
-    let num_indices = indices.len();
     info!("Registering Default Cylinder Mesh..");
-    Ok(MeshResource {
-        name: "CYLINDER".to_string(),
-        vertices,
-        num_vertices,
-        indices,
-        num_indices,
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }
 
 #[repr(C)]
@@ -407,10 +359,7 @@ impl Default for PlanePrimitiveInfo {
     }
 }
 
-pub fn make_plane(
-    info: &PlanePrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_plane(info: &PlanePrimitiveInfo) -> PrimitiveMesh {
     let size = info.size;
 
     let vertex_arr: [Vertex; 4] = [
@@ -453,18 +402,8 @@ pub fn make_plane(
     let vertices = vertex_arr.to_vec();
     let indices = INDICES.to_vec();
 
-    let num_vertices = vertices.len();
-    let num_indices = indices.len();
     info!("Registering Default Plane Mesh..");
-    Ok(MeshResource {
-        name: "PLANE".to_string(),
-        vertices,
-        num_vertices,
-        indices,
-        num_indices,
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }
 
 #[repr(C)]
@@ -484,10 +423,7 @@ impl Default for ConePrimitiveInfo {
     }
 }
 
-pub fn make_cone(
-    info: &ConePrimitiveInfo,
-    _ctx: &mut dashi::Context,
-) -> Result<MeshResource, dashi::GPUError> {
+pub fn make_cone(info: &ConePrimitiveInfo) -> PrimitiveMesh {
     let ConePrimitiveInfo {
         radius,
         height,
@@ -560,16 +496,6 @@ pub fn make_cone(
         indices.push(current);
     }
 
-    let num_vertices = vertices.len();
-    let num_indices = indices.len();
     info!("Registering Default Cone Mesh..");
-    Ok(MeshResource {
-        name: "CONE".to_string(),
-        vertices,
-        num_vertices,
-        indices,
-        num_indices,
-        vertex_buffer: None,
-        index_buffer: None,
-    })
+    PrimitiveMesh { vertices, indices }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -313,7 +313,6 @@ impl RenderEngine {
     }
 
     fn update_mesh_with_renderer(&mut self, handle: Handle<MeshObject>) {
-
         println!("3");
         if let Some(ctx) = self.ctx.as_mut() {
             if let Some(obj) = self.mesh_objects.get_ref(handle) {
@@ -365,11 +364,8 @@ impl RenderEngine {
     }
 
     pub fn create_cube_ex(&mut self, info: &CubePrimitiveInfo) -> Handle<MeshObject> {
-        let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cube(info, ctx).unwrap_or_else(|e| {
-            warn!("failed to create cube primitive: {:?}", e);
-            MeshResource::default()
-        });
+        let prim = geometry_primitives::make_cube(info);
+        let mesh = MeshResource::from_primitive("CUBE", prim);
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -427,11 +423,8 @@ impl RenderEngine {
     }
 
     pub fn create_sphere_ex(&mut self, info: &SpherePrimitiveInfo) -> Handle<MeshObject> {
-        let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_sphere(info, ctx).unwrap_or_else(|e| {
-            warn!("failed to create sphere primitive: {:?}", e);
-            MeshResource::default()
-        });
+        let prim = geometry_primitives::make_sphere(info);
+        let mesh = MeshResource::from_primitive("SPHERE", prim);
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -467,11 +460,8 @@ impl RenderEngine {
     }
 
     pub fn create_cylinder_ex(&mut self, info: &CylinderPrimitiveInfo) -> Handle<MeshObject> {
-        let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cylinder(info, ctx).unwrap_or_else(|e| {
-            warn!("failed to create cylinder primitive: {:?}", e);
-            MeshResource::default()
-        });
+        let prim = geometry_primitives::make_cylinder(info);
+        let mesh = MeshResource::from_primitive("CYLINDER", prim);
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -507,11 +497,8 @@ impl RenderEngine {
     }
 
     pub fn create_plane_ex(&mut self, info: &PlanePrimitiveInfo) -> Handle<MeshObject> {
-        let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_plane(info, ctx).unwrap_or_else(|e| {
-            warn!("failed to create plane primitive: {:?}", e);
-            MeshResource::default()
-        });
+        let prim = geometry_primitives::make_plane(info);
+        let mesh = MeshResource::from_primitive("PLANE", prim);
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -547,11 +534,8 @@ impl RenderEngine {
     }
 
     pub fn create_cone_ex(&mut self, info: &ConePrimitiveInfo) -> Handle<MeshObject> {
-        let ctx = self.ctx.as_mut().expect("render context not initialized");
-        let mesh = geometry_primitives::make_cone(info, ctx).unwrap_or_else(|e| {
-            warn!("failed to create cone primitive: {:?}", e);
-            MeshResource::default()
-        });
+        let prim = geometry_primitives::make_cone(info);
+        let mesh = MeshResource::from_primitive("CONE", prim);
         let material = self
             .database
             .fetch_material("DEFAULT")
@@ -637,7 +621,6 @@ impl RenderEngine {
                 );
             }
         }
-
 
         println!("2");
         // After transform update, refresh GPU mesh


### PR DESCRIPTION
## Summary
- Introduce `PrimitiveMesh` and helper to build GPU-ready `MeshResource`
- Generate cube, sphere, and other primitives as CPU vertex/index data
- Build mesh resources from primitives and upload through existing registration path

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689777fd4bf0832aa5e3362df91583a2