### PR TITLE
test: add mesh registration render test

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -297,7 +297,7 @@ impl RenderEngine {
         self.mesh_objects.release(handle);
     }
 
-    fn register_mesh_with_renderer(&mut self, handle: Handle<MeshObject>) {
+    pub fn register_mesh_with_renderer(&mut self, handle: Handle<MeshObject>) {
         if let Some(ctx) = self.ctx.as_mut() {
             if let Some(obj) = self.mesh_objects.get_mut_ref(handle) {
                 let display = self.display.as_mut();
@@ -310,6 +310,13 @@ impl RenderEngine {
                 }
             }
         }
+    }
+
+    pub fn mesh_renderer_handle(&self, handle: Handle<MeshObject>) -> Option<usize> {
+        self
+            .mesh_objects
+            .get_ref(handle)
+            .and_then(|obj| obj.renderer_handle)
     }
 
     fn update_mesh_with_renderer(&mut self, handle: Handle<MeshObject>) {

--- a/tests/register_mesh_render.rs
+++ b/tests/register_mesh_render.rs
@@ -1,0 +1,41 @@
+use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo};
+use serial_test::serial;
+use tempfile::tempdir;
+
+fn run_backend(backend: RenderBackend) {
+    let dir = tempdir().unwrap();
+    let base = dir.path();
+    let db_dir = base.join("database");
+    std::fs::create_dir(&db_dir).unwrap();
+    std::fs::write(db_dir.join("db.json"), "{}").unwrap();
+    std::fs::write(base.join("koji.json"), "{\"nodes\":[],\"edges\":[]}").unwrap();
+
+    let mut render = RenderEngine::new(&RenderEngineInfo {
+        application_path: base.to_str().unwrap().into(),
+        scene_info: None,
+        headless: true,
+        backend,
+        canvas_extent: None,
+    })
+    .expect("renderer init");
+
+    let handle = render.create_triangle();
+    render.update(0.0);
+    render.register_mesh_with_renderer(handle);
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        render.update(0.0);
+    }))
+    .is_ok());
+}
+
+#[test]
+#[serial]
+fn canvas_register_mesh_and_render() {
+    run_backend(RenderBackend::Canvas);
+}
+
+#[test]
+#[serial]
+fn graph_register_mesh_and_render() {
+    run_backend(RenderBackend::Graph);
+}


### PR DESCRIPTION
## Summary
- expose `register_mesh_with_renderer` and provide `mesh_renderer_handle` to inspect GPU registration
- add integration test that registers a mesh and exercises the `render` path for both Canvas and Graph backends

## Testing
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_6897873cdbdc832aadb5d11863191e5c