### PR TITLE
Persist test images for inspection

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+use image::RgbaImage;
+
+/// Save the provided images under `target/test_images` for manual inspection
+/// and assert that their raw pixel data matches.
+pub fn assert_images_eq(name: &str, actual: &RgbaImage, expected: &RgbaImage) {
+    save_images(name, actual, expected);
+    assert_eq!(actual.as_raw(), expected.as_raw());
+}
+
+fn save_images(name: &str, actual: &RgbaImage, expected: &RgbaImage) {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("test_images");
+    std::fs::create_dir_all(&dir).expect("create test_images directory");
+    let name = name.replace("::", "_");
+    actual
+        .save(dir.join(format!("{name}_actual.png")))
+        .expect("save actual image");
+    expected
+        .save(dir.join(format!("{name}_expected.png")))
+        .expect("save expected image");
+}

--- a/tests/directional_light_render.rs
+++ b/tests/directional_light_render.rs
@@ -3,6 +3,7 @@ use image::{Rgba, RgbaImage};
 use meshi::render::{DirectionalLightInfo, RenderBackend, RenderEngine, RenderEngineInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     let mut img = RgbaImage::new(width, height);
@@ -27,7 +28,7 @@ fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     img
 }
 
-fn run_backend(backend: RenderBackend) {
+fn run_backend(backend: RenderBackend, name: &str) {
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();
@@ -70,17 +71,23 @@ fn run_backend(backend: RenderBackend) {
     render.create_triangle();
     let img = render.render_to_image(EXTENT).expect("render to image");
     let expected = expected_triangle(EXTENT[0], EXTENT[1]);
-    assert_eq!(img.as_raw(), expected.as_raw());
+    common::assert_images_eq(name, &img, &expected);
 }
 
 #[test]
 #[serial]
 fn canvas_directional_light() {
-    run_backend(RenderBackend::Canvas);
+    run_backend(
+        RenderBackend::Canvas,
+        concat!(module_path!(), "::", stringify!(canvas_directional_light)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_directional_light() {
-    run_backend(RenderBackend::Graph);
+    run_backend(
+        RenderBackend::Graph,
+        concat!(module_path!(), "::", stringify!(graph_directional_light)),
+    );
 }

--- a/tests/graph_backend.rs
+++ b/tests/graph_backend.rs
@@ -2,6 +2,7 @@ use image::RgbaImage;
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn render_triangle(backend: RenderBackend) -> RgbaImage {
     const EXTENT: [u32; 2] = [64, 64];
@@ -33,6 +34,10 @@ fn render_triangle(backend: RenderBackend) -> RgbaImage {
 fn graph_backend_matches_canvas() {
     let canvas = render_triangle(RenderBackend::Canvas);
     let graph = render_triangle(RenderBackend::Graph);
-    assert_eq!(canvas.as_raw(), graph.as_raw());
+    common::assert_images_eq(
+        concat!(module_path!(), "::", stringify!(graph_backend_matches_canvas)),
+        &canvas,
+        &graph,
+    );
 }
 

--- a/tests/render_output.rs
+++ b/tests/render_output.rs
@@ -2,6 +2,7 @@ use image::{Rgba, RgbaImage};
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     let mut img = RgbaImage::new(width, height);
@@ -26,7 +27,7 @@ fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     img
 }
 
-fn run_backend(backend: RenderBackend) {
+fn run_backend(backend: RenderBackend, name: &str) {
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();
@@ -49,17 +50,23 @@ fn run_backend(backend: RenderBackend) {
         .render_to_image(EXTENT)
         .expect("render to image");
     let expected = expected_triangle(EXTENT[0], EXTENT[1]);
-    assert_eq!(img.as_raw(), expected.as_raw());
+    common::assert_images_eq(name, &img, &expected);
 }
 
 #[test]
 #[serial]
 fn canvas_red_triangle() {
-    run_backend(RenderBackend::Canvas);
+    run_backend(
+        RenderBackend::Canvas,
+        concat!(module_path!(), "::", stringify!(canvas_red_triangle)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_red_triangle() {
-    run_backend(RenderBackend::Graph);
+    run_backend(
+        RenderBackend::Graph,
+        concat!(module_path!(), "::", stringify!(graph_red_triangle)),
+    );
 }

--- a/tests/render_primitives.rs
+++ b/tests/render_primitives.rs
@@ -2,6 +2,7 @@ use image::{Rgba, RgbaImage};
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     let mut img = RgbaImage::new(width, height);
@@ -26,7 +27,7 @@ fn expected_triangle(width: u32, height: u32) -> RgbaImage {
     img
 }
 
-fn run_backend<F>(backend: RenderBackend, create: F)
+fn run_backend<F>(backend: RenderBackend, create: F, name: &str)
 where
     F: Fn(&mut RenderEngine),
 {
@@ -65,91 +66,131 @@ where
     create(&mut render);
     let img = render.render_to_image(EXTENT).expect("render to image");
     let expected = expected_triangle(EXTENT[0], EXTENT[1]);
-    assert_eq!(img.as_raw(), expected.as_raw());
+    common::assert_images_eq(name, &img, &expected);
 }
 
 #[test]
 #[serial]
 fn canvas_cube() {
-    run_backend(RenderBackend::Canvas, |r| {
-        r.create_cube();
-    });
+    run_backend(
+        RenderBackend::Canvas,
+        |r| {
+            r.create_cube();
+        },
+        concat!(module_path!(), "::", stringify!(canvas_cube)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_cube() {
-    run_backend(RenderBackend::Graph, |r| {
-        r.create_cube();
-    });
+    run_backend(
+        RenderBackend::Graph,
+        |r| {
+            r.create_cube();
+        },
+        concat!(module_path!(), "::", stringify!(graph_cube)),
+    );
 }
 
 #[test]
 #[serial]
 fn canvas_sphere() {
-    run_backend(RenderBackend::Canvas, |r| {
-        r.create_sphere();
-    });
+    run_backend(
+        RenderBackend::Canvas,
+        |r| {
+            r.create_sphere();
+        },
+        concat!(module_path!(), "::", stringify!(canvas_sphere)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_sphere() {
-    run_backend(RenderBackend::Graph, |r| {
-        r.create_sphere();
-    });
+    run_backend(
+        RenderBackend::Graph,
+        |r| {
+            r.create_sphere();
+        },
+        concat!(module_path!(), "::", stringify!(graph_sphere)),
+    );
 }
 
 #[test]
 #[serial]
 fn canvas_cylinder() {
     use meshi::render::database::geometry_primitives::CylinderPrimitiveInfo;
-    run_backend(RenderBackend::Canvas, |r| {
-        r.create_cylinder_ex(&CylinderPrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Canvas,
+        |r| {
+            r.create_cylinder_ex(&CylinderPrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(canvas_cylinder)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_cylinder() {
     use meshi::render::database::geometry_primitives::CylinderPrimitiveInfo;
-    run_backend(RenderBackend::Graph, |r| {
-        r.create_cylinder_ex(&CylinderPrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Graph,
+        |r| {
+            r.create_cylinder_ex(&CylinderPrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(graph_cylinder)),
+    );
 }
 
 #[test]
 #[serial]
 fn canvas_plane() {
     use meshi::render::database::geometry_primitives::PlanePrimitiveInfo;
-    run_backend(RenderBackend::Canvas, |r| {
-        r.create_plane_ex(&PlanePrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Canvas,
+        |r| {
+            r.create_plane_ex(&PlanePrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(canvas_plane)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_plane() {
     use meshi::render::database::geometry_primitives::PlanePrimitiveInfo;
-    run_backend(RenderBackend::Graph, |r| {
-        r.create_plane_ex(&PlanePrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Graph,
+        |r| {
+            r.create_plane_ex(&PlanePrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(graph_plane)),
+    );
 }
 
 #[test]
 #[serial]
 fn canvas_cone() {
     use meshi::render::database::geometry_primitives::ConePrimitiveInfo;
-    run_backend(RenderBackend::Canvas, |r| {
-        r.create_cone_ex(&ConePrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Canvas,
+        |r| {
+            r.create_cone_ex(&ConePrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(canvas_cone)),
+    );
 }
 
 #[test]
 #[serial]
 fn graph_cone() {
     use meshi::render::database::geometry_primitives::ConePrimitiveInfo;
-    run_backend(RenderBackend::Graph, |r| {
-        r.create_cone_ex(&ConePrimitiveInfo::default());
-    });
+    run_backend(
+        RenderBackend::Graph,
+        |r| {
+            r.create_cone_ex(&ConePrimitiveInfo::default());
+        },
+        concat!(module_path!(), "::", stringify!(graph_cone)),
+    );
 }


### PR DESCRIPTION
## Summary
- save actual and expected render outputs from tests under `target/test_images`
- update rendering tests to write uniquely named frames for manual review

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898b0775664832a9101798d24fa3378