### PR TITLE
Gracefully handle missing graph config

### DIFF
--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -29,13 +29,17 @@ impl GraphRenderer {
                 Ok(s) => Some(s),
                 Err(e) => {
                     warn!("failed to read scene config {path}: {e}");
-                    return Err(RenderError::GraphConfig(e));
+                    None
                 }
             }
         } else {
             None
         };
         Ok(Self { graph_json, renderer: None, next_mesh: 0, headless })
+    }
+
+    fn default_graph(_headless: bool) -> RenderGraph {
+        RenderGraph::new()
     }
 
     fn init(&mut self, ctx: &mut dashi::Context) -> Result<(), RenderError> {
@@ -45,7 +49,7 @@ impl GraphRenderer {
             let graph = if let Some(json) = &self.graph_json {
                 io::from_json(json).map_err(RenderError::GraphParse)?
             } else {
-                RenderGraph::new()
+                Self::default_graph(self.headless)
             };
 
             let mut renderer = if self.headless {


### PR DESCRIPTION
## Summary
- Avoid failing when scene config cannot be read; log warning instead
- Provide a default render graph helper and use it when no config is present

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898f43f5760832aaafe2194795f3cdb