### PR TITLE
Select available graph output for graph renderer

### DIFF
--- a/src/render/graph.rs
+++ b/src/render/graph.rs
@@ -72,11 +72,20 @@ impl GraphRenderer {
                 "#,
                 frag
             );
+            let outputs = renderer.graph().output_images();
+            let output_name = if !self.headless && outputs.iter().any(|o| o == "swapchain") {
+                "swapchain".to_string()
+            } else {
+                outputs
+                    .first()
+                    .cloned()
+                    .expect("render graph has no outputs")
+            };
 
             let (pass, _) = renderer
                 .graph()
-                .render_pass_for_output("swapchain")
-                .expect("missing swapchain output");
+                .render_pass_for_output(&output_name)
+                .expect(&format!("missing {output_name} output"));
 
             let mut pso = PipelineBuilder::new(ctx, "graph_pso")
                 .vertex_shader(vert)


### PR DESCRIPTION
## Summary
- Dynamically select render graph output, preferring `swapchain` when available and falling back to first output otherwise
- Use the chosen output's render pass when building the pipeline

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6898f9323e34832a8eefa3d6230128fc