### PR TITLE
Enable Vulkan validation in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "image 0.24.9",
  "inline-spirv",
  "koji",
+ "libc",
  "rayon",
  "rodio",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ inline-spirv = "0.2.1"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+libc = "0.2"
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,44 @@
-use std::path::PathBuf;
+use std::{fs::File, io::Read, os::unix::io::FromRawFd, path::PathBuf};
 use image::RgbaImage;
+
+/// Guard that enables Vulkan validation layers and captures messages written to
+/// `stderr`. When dropped, it asserts that no validation errors or warnings were
+/// emitted.
+pub struct ValidationGuard {
+    read_fd: i32,
+    stderr_fd: i32,
+}
+
+impl ValidationGuard {
+    pub fn new() -> Self {
+        std::env::set_var("DASHI_VALIDATION", "1");
+        unsafe {
+            let stderr_fd = libc::dup(libc::STDERR_FILENO);
+            assert!(stderr_fd >= 0, "dup stderr failed");
+            let mut fds = [0; 2];
+            assert_eq!(libc::pipe(fds.as_mut_ptr()), 0, "pipe failed");
+            libc::dup2(fds[1], libc::STDERR_FILENO);
+            libc::close(fds[1]);
+            Self { read_fd: fds[0], stderr_fd }
+        }
+    }
+}
+
+impl Drop for ValidationGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::fflush(std::ptr::null_mut());
+            libc::dup2(self.stderr_fd, libc::STDERR_FILENO);
+            libc::close(self.stderr_fd);
+            let mut file = File::from_raw_fd(self.read_fd);
+            let mut output = String::new();
+            let _ = file.read_to_string(&mut output);
+            if output.contains("[ERROR]") || output.contains("[WARNING]") {
+                panic!("Vulkan validation reported issues:\n{output}");
+            }
+        }
+    }
+}
 
 /// Save the provided images under `target/test_images` for manual inspection
 /// and assert that their raw pixel data matches.

--- a/tests/directional_light_render.rs
+++ b/tests/directional_light_render.rs
@@ -29,6 +29,7 @@ fn expected_triangle(width: u32, height: u32) -> RgbaImage {
 }
 
 fn run_backend(backend: RenderBackend, name: &str) {
+    let _guard = common::ValidationGuard::new();
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -8,8 +8,10 @@ use meshi::render::{
 };
 use meshi::*;
 use std::ffi::CString;
+mod common;
 
 fn main() {
+    let _guard = common::ValidationGuard::new();
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
     let info = MeshiEngineInfo {

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -13,6 +13,7 @@ use winit::event::{
     DeviceEvent, ElementState, Event as WEvent, KeyboardInput, ModifiersState, MouseScrollDelta,
     TouchPhase, VirtualKeyCode, WindowEvent,
 };
+mod common;
 
 extern "C" fn cb(_ev: *mut Event, data: *mut c_void) {
     let counter: &AtomicUsize = unsafe { &*(data as *const AtomicUsize) };
@@ -20,6 +21,7 @@ extern "C" fn cb(_ev: *mut Event, data: *mut c_void) {
 }
 
 fn main() {
+    let _guard = common::ValidationGuard::new();
     // Test conversion from winit events
     let window_id: winit::window::WindowId = unsafe { std::mem::zeroed() };
 

--- a/tests/gfx_create_renderable_err.rs
+++ b/tests/gfx_create_renderable_err.rs
@@ -2,9 +2,11 @@ use dashi::utils::Handle;
 use glam::Mat4;
 use meshi::{*, render::RenderBackend};
 use std::ffi::CString;
+mod common;
 
 #[test]
 fn invalid_info_returns_default_handle() {
+    let _guard = common::ValidationGuard::new();
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
     let info = MeshiEngineInfo {

--- a/tests/gfx_release.rs
+++ b/tests/gfx_release.rs
@@ -1,8 +1,10 @@
 use meshi::render::{DirectionalLightInfo, RenderBackend};
 use meshi::*;
 use std::ffi::CString;
+mod common;
 
 fn main() {
+    let _guard = common::ValidationGuard::new();
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
     let info = MeshiEngineInfo {

--- a/tests/gfx_transform_invalid.rs
+++ b/tests/gfx_transform_invalid.rs
@@ -3,9 +3,11 @@ use glam::Mat4;
 use meshi::render::RenderBackend;
 use meshi::*;
 use std::ffi::CString;
+mod common;
 
 #[test]
 fn set_transform_with_invalid_handle_does_nothing() {
+    let _guard = common::ValidationGuard::new();
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
     let info = MeshiEngineInfo {

--- a/tests/graph_backend.rs
+++ b/tests/graph_backend.rs
@@ -5,6 +5,7 @@ use tempfile::tempdir;
 mod common;
 
 fn render_triangle(backend: RenderBackend) -> RgbaImage {
+    let _guard = common::ValidationGuard::new();
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().expect("temp dir");
     let base = dir.path();

--- a/tests/mesh_physics.rs
+++ b/tests/mesh_physics.rs
@@ -3,8 +3,10 @@ use meshi::physics::{ActorStatus, RigidBodyInfo};
 use meshi::render::{database::geometry_primitives::CubePrimitiveInfo, RenderBackend};
 use meshi::*;
 use std::ffi::CString;
+mod common;
 
 fn main() {
+    let _guard = common::ValidationGuard::new();
     let name = CString::new("test").unwrap();
     let loc = CString::new(".").unwrap();
     let info = MeshiEngineInfo {

--- a/tests/register_mesh_render.rs
+++ b/tests/register_mesh_render.rs
@@ -1,8 +1,10 @@
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn run_backend(backend: RenderBackend) {
+    let _guard = common::ValidationGuard::new();
     let dir = tempdir().unwrap();
     let base = dir.path();
     let db_dir = base.join("database");

--- a/tests/render_output.rs
+++ b/tests/render_output.rs
@@ -28,6 +28,7 @@ fn expected_triangle(width: u32, height: u32) -> RgbaImage {
 }
 
 fn run_backend(backend: RenderBackend, name: &str) {
+    let _guard = common::ValidationGuard::new();
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();

--- a/tests/render_primitives.rs
+++ b/tests/render_primitives.rs
@@ -31,6 +31,7 @@ fn run_backend<F>(backend: RenderBackend, create: F, name: &str)
 where
     F: Fn(&mut RenderEngine),
 {
+    let _guard = common::ValidationGuard::new();
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -1,8 +1,10 @@
 use image::{Rgba, RgbaImage};
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
 use std::fs;
+mod common;
 
 fn main() {
+    let _guard = common::ValidationGuard::new();
     // Create a temporary directory for the database resources.
     let mut dir = std::env::temp_dir();
     dir.push("meshi_scene_test");

--- a/tests/scene_fail.rs
+++ b/tests/scene_fail.rs
@@ -1,8 +1,10 @@
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
 use std::fs;
+mod common;
 
 #[test]
 fn records_missing_resources() {
+    let _guard = common::ValidationGuard::new();
     // Create temporary directory with minimal database.
     let dir = tempfile::tempdir().unwrap();
     let db_dir = dir.path().join("database");

--- a/tests/scene_render.rs
+++ b/tests/scene_render.rs
@@ -2,8 +2,10 @@ use image::{Rgba, RgbaImage};
 use meshi::render::{RenderBackend, RenderEngine, RenderEngineInfo, SceneInfo};
 use serial_test::serial;
 use tempfile::tempdir;
+mod common;
 
 fn run_backend(backend: RenderBackend) {
+    let _guard = common::ValidationGuard::new();
     const EXTENT: [u32; 2] = [64, 64];
     let dir = tempdir().unwrap();
     let base = dir.path();


### PR DESCRIPTION
## Summary
- add `ValidationGuard` to enable Vulkan validation layers and capture errors
- wrap render and engine tests with `ValidationGuard`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a16ef32e70832a9a1079e7625b0eb9